### PR TITLE
docs: PubSub messages inventory + security audit plan (RCQ-contextualized)

### DIFF
--- a/docs/pubsub_messages.md
+++ b/docs/pubsub_messages.md
@@ -1,0 +1,96 @@
+# Inventaire des messages PubSub publiés par le serveur RedCrossQuest
+
+## 1. Vue d'ensemble — 3 topics utilisés sur 4 déclarés
+
+Déclaration dans `server/src/settings.php` (clé `PubSub`) :
+
+```php
+'PubSub'      => [
+  'tronc_queteur_update_topic' => 'tronc_queteur_update',
+  'tronc_queteur_create_topic' => 'tronc_queteur_create',
+  'queteur_approval_topic'     => 'queteur_approval_topic',
+  'ul_update_topic'            => 'ul_update'
+],
+```
+
+Service générique : `server/src/Service/PubSubService.php::publish($topic, $data, $attributes, $jsonEncode=true, $raiseOnError=false)`.
+
+Format publié = `{"data": json_encode($data), "attributes": {…}}`.
+
+---
+
+## 2. Détail par message
+
+### A) `tronc_queteur_create`
+
+| | |
+|---|---|
+| **Site** | `server/src/routes/routesActions/troncsQueteurs/PrepareTroncQueteur.php:146` |
+| **Quand** | À la **préparation** d'un tronc-quêteur (un quêteur reçoit son tronc avant de partir). |
+| **Payload (JSON)** | `TroncQueteurEntity` complet **après** `preparePubSubPublishing()` : dates Carbon converties en string (`Y-m-d H:i:s`), `tronc` et `rowCount` supprimés, et enrichi de `queteur` (`QueteurEntity` allégé, sans `referent_volunteerQueteur`/`user`) + `point_quete` (sans `max_people`). |
+| **Attributes** | `ulId`, `uId` (user qui prépare), `queteurId`, `troncQueteurId` (tous en string) |
+| **Finalité** | Alimenter BigQuery (analytique) **et** synchroniser Firestore pour que RedQuest (app mobile quêteur) voie l'affectation tronc↔quêteur↔point de quête en temps réel. |
+
+### B) `tronc_queteur_update`
+
+| | |
+|---|---|
+| **Sites** | `server/src/routes/routesActions/troncsQueteurs/SaveCoinsOnTroncQueteur.php:138` *et* `SaveAsAdminOnTroncQueteur.php:93` |
+| **Quand** | Au comptage des espèces/billets/CB/chèques du tronc (mode normal ou mode admin). |
+| **Payload (JSON)** | `TroncQueteurEntity` **complet rechargé depuis la base** via `getTroncQueteurById()` puis `preparePubSubPublishing()`. Contient tous les comptages (`euro500…euro001`, dons CB/chèques, `amount`, `weight`, `comptage`, `time_spent_in_hours`, `coins_money_bag_id`, `bills_money_bag_id`, etc.) + flag `saveAsAdmin=1` quand mode admin. |
+| **Attributes** | `ulId`, `uId`, `queteurId`, `troncQueteurId` |
+| **Finalité** | Pousser les montants définitifs vers **BigQuery** pour les stats UL/quêteur, et déclencher en aval `ComputeULStats` / `ULTriggerRecompute` qui recalculent les agrégats annuels. |
+
+### C) `queteur_approval_topic`
+
+| | |
+|---|---|
+| **Sites** | `server/src/routes/routesActions/queteurs/ApproveQueteurRegistration.php:111` *et* `AssociateRegistrationWithExistingQueteur.php:107` |
+| **Quand** | Quand un responsable UL **valide** (ou associe à un quêteur existant) une demande d'inscription envoyée depuis RedQuest. |
+| **Payload (JSON)** | `QueteurEntity` complet : `id`, `email`, `first_name`, `last_name`, `nivol`, `mobile`, `ul_id`/`ul_name`, `birthdate`, `man`, `active`, `registration_id`, `registration_approved`, `reject_reason`, `queteur_registration_token`, `firebase_uid`, `firebase_sign_in_provider`, etc. (voir `QueteurEntity::$_fieldList`). |
+| **Attributes** | `ulId`, `uId` (validateur), `queteurId`, `registrationId` |
+| **Finalité** | Déclenche la **Cloud Function `notifyRQOfRegistApproval`** (abonnée à ce topic — cf. `GCP/init_lib/common.sh:30`) qui notifie l'utilisateur RedQuest du verdict (approuvé/rejeté) et synchronise Firestore. |
+
+### D) `ul_update_topic` → `ul_update` — déclaré mais non utilisé côté serveur PHP
+
+| | |
+|---|---|
+| **Sites côté PHP** | aucun (`grep` négatif sur `ul_update_topic` dans `server/src/**`) |
+| **Producteur réel** | la Cloud Function `ComputeULStats` (HTTP). |
+| **Consommateur** | la Cloud Function `ULTriggerRecompute` est abonnée à `trigger_ul_update` (pas `ul_update`) — cf. `GCP/init_lib/common.sh:32`. Le topic `ul_update` semble plutôt branché Firestore/BigQuery. |
+| **Constat** | La clé `ul_update_topic` dans `settings.php` est **morte côté backend RCQ** — c'est de la config résiduelle qui pourrait être nettoyée (à confirmer avec l'usage côté `rcq-functions-v2`). |
+
+---
+
+## 3. Topics PubSub créés mais inutilisés ailleurs
+
+`GCP/init_lib/create_topics.sh` provisionne 8 topics. Confrontation aux usages :
+
+| Topic | Producteur PHP | Consommateur (CF) | Statut |
+|---|---|---|---|
+| `tronc_queteur_create` | ✅ PrepareTroncQueteur | ? (probablement BigQuery sink) | **actif** |
+| `tronc_queteur_update` | ✅ SaveCoins + SaveAsAdmin | ? | **actif** |
+| `tronc_queteur_depart` | ❌ aucun | ? | **mort** (les départs passent par `tronc_queteur_update` avec `depart` renseigné) |
+| `tronc_queteur_return` | ❌ aucun | ? | **mort** (idem `retour`) |
+| `tronc_queteur_updateAsAdmin` | ❌ aucun | ? | **mort** (flag `saveAsAdmin=1` dans `tronc_queteur_update`) |
+| `queteur_approval_topic` | ✅ Approve + Associate | ✅ `notifyRQOfRegistApproval` | **actif** |
+| `ul_update` | ❌ aucun (PHP) | ? | mort côté PHP |
+| `trigger_ul_update` | ❌ aucun (PHP) | ✅ `ULTriggerRecompute` | trigger CF→CF, hors scope serveur |
+
+---
+
+## 4. Récapitulatif tableau
+
+| # | Topic | Émis par (PHP) | Payload | Attributes | Finalité |
+|---|---|---|---|---|---|
+| 1 | `tronc_queteur_create` | `PrepareTroncQueteur` | `TroncQueteurEntity` + `queteur` + `point_quete` (allégés, dates en string) | ulId, uId, queteurId, troncQueteurId | Synchro Firestore (RedQuest) + ingestion BigQuery |
+| 2 | `tronc_queteur_update` | `SaveCoinsOnTroncQueteur`, `SaveAsAdminOnTroncQueteur` | `TroncQueteurEntity` complet rechargé + flag `saveAsAdmin` | idem | Comptages → BigQuery, déclenche recompute stats UL |
+| 3 | `queteur_approval_topic` | `ApproveQueteurRegistration`, `AssociateRegistrationWithExistingQueteur` | `QueteurEntity` complet | ulId, uId, queteurId, registrationId | Trigger CF `notifyRQOfRegistApproval` → notif RedQuest + Firestore |
+| 4 | `ul_update` *(déclaré)* | — | — | — | Inutilisé côté PHP |
+
+---
+
+## 5. Notes de fiabilité
+
+- 4 des 5 publishes utilisent `$raiseExceptionInCaseOfError=true` mais sont **enveloppés d'un `try/catch` qui swallow** l'exception (commentaire explicite `//do not rethrow`). Donc une panne PubSub **n'échoue pas** la requête HTTP — c'est intentionnel (le caissier ne doit pas être bloqué) mais ça veut dire qu'**aucune retry-queue** n'existe : un message perdu est perdu. À noter si on veut un jour fiabiliser (Outbox pattern, dead-letter, etc.).
+- Avec PHP 8.5, `preparePubSubPublishing()` mute les `Carbon` en `string` — d'où les types unions (`Carbon|string|null`) sur les propriétés date de `TroncQueteurEntity`. Pas un risque, juste une dette de modèle (l'entité sert à la fois de DTO DB et de DTO PubSub).

--- a/docs/security-audit-rcq.md
+++ b/docs/security-audit-rcq.md
@@ -1,0 +1,128 @@
+# Security Audit — RedCrossQuest (plan d'exécution)
+
+Plan d'audit sécurité **contextualisé** au repo RedCrossQuest, dérivé du template générique `docs/security-audit.md`. **Ce document est un plan, pas une implémentation** : à exécuter wave par wave, avec approbation utilisateur entre chaque wave.
+
+> Tracking : todo « *Security audit RCQ — execute waves from docs/security-audit-rcq.md* ».
+
+---
+
+## 0. Contexte projet (placeholders remplis)
+
+- **Repo** : `/Users/tom/Projects/RedCrossQuest` — branche `master` — remote `github.com/dev-mansonthomas/RedCrossQuest`.
+- **Stack** :
+  - **Backend** : PHP 8.5 + Slim 4 (`slim/slim ^4.15`) + PHP-DI 7 + `lcobucci/jwt ^5.6` (HS256, symétrique) + `kreait/firebase-php ^7.18` + PDO/MySQL + `phpmailer` + `sendgrid` + Google Cloud SDK (PubSub, Firestore, Secret Manager).
+  - **Frontend** : AngularJS 1.8.3 (**EOL depuis dec 2021**), jQuery 2.2.4, bootstrap-sass 3.4.3, Gulp 5, Node 22, ESLint 9. Build statique servi via Cloud Run (front + back même domaine app).
+  - **Cloud Functions** : Gen1 historiques (Node) déployées depuis ce repo via `GCP/deploy_cloudFunctions.sh` — **migration en cours vers `/Users/tom/Projects/rcq-functions-v2/` (Python 3.13 Gen2, audit séparé, hors scope ici).**
+  - **Infra runtime** : Cloud Run (`runtime: php85` côté GAE template), Cloud SQL MySQL (unix socket), Firestore, PubSub, Secret Manager.
+- **Environnements** : 3 projets GCP — `rcq-fr-dev`, `rcq-fr-test`, `rcq-fr-prod`. Déploiement **manuel** via `./gcp-deploy.sh <country> <env> <target>` (cibles : `route`/`front`/`back`/`fb`/`functions`/`all`). **Pas de CI/CD** (`.github/workflows/` absent).
+- **Secrets** : `MYSQL_PASSWORD`, clés Firebase, JWT secret, SendGrid API key, ReCaptcha, etc. — tous récupérés **runtime** via `SecretManagerService` (jamais en clair dans le repo). `.env` local git-ignored, `.env.example` propre.
+
+---
+
+## 1. Recon — état des lieux (read-only, déjà fait pour ce plan)
+
+| Élément | Valeur |
+|---|---|
+| Lockfiles | `client/package-lock.json`, `server/composer.lock`, `server/openapi/package-lock.json` |
+| Dependabot alerts (GitHub) | **56** (2 critical, 19 high, 29 moderate, 6 low) — confirmé au push de la PR #212 |
+| GitHub Actions | **aucun** workflow (à introduire en Wave 5) |
+| Dependabot/Renovate | non configuré |
+| JWT | HS256, secret symétrique en clair en RAM (`InMemory::plainText($jwtSecret)`), `iss`/`aud` validés |
+| Headers HTTP (nginx) | ✅ `X-Frame-Options DENY`, ✅ `X-Content-Type-Options nosniff`, ✅ `fastcgi_hide_header X-Powered-By` — ❌ **pas de HSTS, pas de CSP, pas de Referrer-Policy, pas de Permissions-Policy** |
+| CORS | aucune ligne `Access-Control-*` côté serveur ni nginx (front + back même origine via Cloud Run → OK par construction, à confirmer pour graph.redcrossquest.com) |
+| Postinstall scripts npm | non audité ; 2 deps GitHub-hosted (`dev-mansonthomas/angular-qr-updated`, `angular-qr-scanner-updated`) — fork perso, pinné par **tag** pas SHA |
+| Versions à risque connues | AngularJS 1.8.3 (EOL), jQuery 2.2.4 (CVE-2020-11022/23 sur `<2.2.0` mais reste vieux), bootstrap-sass 3.x (BS3 EOL), `angular-jwt@0.1.11` (10+ ans), Gen1 Cloud Functions (Node runtime ?). |
+
+---
+
+## 2. Phase 1.5 — Supply chain : applicabilité aux paquets RCQ
+
+| Attaque (template) | Applicable à RCQ ? | Raison |
+|---|---|---|
+| **Shai-Hulud** (sept 2025, `@ctrl/tinycolor`, `@nativescript-community`…) | ⚠️ **à vérifier** | aucun de ces paquets visible directement dans `client/package.json` mais transitifs possibles via `gulp-*`, `karma-*` → grep `npm ls` requis |
+| **s1ngularity / nx** (août 2025) | ❌ non applicable | pas de `nx` ni `@nrwl/*` dans le repo |
+| **Qix / chalk** (sept 2024) | ⚠️ **à vérifier** | `chalk ^4.1.2` présent en devDep — version OK, mais transitifs de `gulp-*` à vérifier (`debug`, `ansi-styles`, etc.) |
+| **lottie-player** (oct 2024) | ❌ non applicable | pas utilisé |
+| **ua-parser-js** (2021) | ⚠️ transitif potentiel | grep requis dans `package-lock.json` |
+| **node-ipc** (2022) | ❌ non applicable | pas direct, transitif possible |
+| **xz-utils CVE-2024-3094** | ⚠️ **à vérifier sur Docker images** | nos images `docker/php-fpm` et `docker/node` reposent sur quoi ? (alpine/debian-slim) → audit base images |
+| **tj-actions/changed-files** (mars 2025) | ❌ non applicable | pas de workflows GitHub Actions… **mais** devient applicable dès qu'on en ajoute en Wave 5 |
+
+---
+
+## 3. Plan par waves — adapté RCQ
+
+### Wave 0 — Pré-requis (sans dev, juste outil)
+- [ ] `composer audit --locked` (PHP 8.5) — capturer le baseline.
+- [ ] `npm audit --json` côté `client/` et `server/openapi/` — capturer le baseline.
+- [ ] Trier les **56 Dependabot alerts** par sévérité + paquet, comparer aux deux audits ci-dessus pour éliminer les doublons.
+- [ ] Lister les images de base Docker (`docker/php-fpm/Dockerfile`, `docker/node/Dockerfile`, `docker/nginx/Dockerfile`) et leur tag de digest (besoin pour CVE xz, glibc, etc.).
+
+### Wave 1 — Supply chain (CRITIQUE)
+1. **Composer audit** : résoudre tous les `high`/`critical` sur `composer.lock`. Stack auth-critique : `lcobucci/jwt`, `firebase/php-jwt` transitif éventuel, `kreait/firebase-php`, `guzzlehttp/guzzle`, `symfony/http-client`.
+2. **npm audit `client/`** : prioriser les paquets touchant l'exécution navigateur (`angular*`, `jquery`, `bootstrap-sass`, `moment`, `zxcvbn`).
+3. **Phase 1.5 worms** : exécuter les 3 scans (Shai-Hulud / Qix / postinstall) sur `client/package-lock.json` et `server/openapi/package-lock.json`.
+4. **Forks GitHub** : `dev-mansonthomas/angular-qr-*` → pinner par **commit SHA** au lieu du tag (immuable). Vérifier que les forks n'ont pas dérivé de leur upstream pour autre chose qu'un bump.
+5. **Decision point** : AngularJS 1.8.3 EOL + jQuery 2.2.4. Le vrai fix = sortir d'AngularJS (projet hors scope, déjà documenté dans `docs/frontend_upgrade_audit.md`). À court terme : **accepter le risque documenté** et limiter la surface (CSP en Wave 3).
+
+### Wave 2 — Auth, secrets, JWT
+1. **JWT** : HS256 acceptable tant que le secret est ≥ 256 bits et stocké uniquement en Secret Manager (déjà le cas). **À vérifier** : longueur effective du secret en prod (`gcloud secrets versions access` sans logger la valeur, juste `wc -c`).
+2. **JWT claims** : `exp` court, `iss`/`aud` validés (✅ dans `AuthorisationMiddleware`). Ajouter `nbf` si absent. Vérifier la **rotation** (qu'arrive-t-il si on change le secret en prod — tous les utilisateurs se reconnectent ?).
+3. **Firebase admin SDK** : `kreait/firebase-php` 7.18. Vérifier que les tokens RedQuest reçus côté Cloud Functions sont validés (signature + `aud` = projet GCP correct).
+4. **Secret Manager** : audit IAM. Chaque service account (Cloud Run runtime, CI futur, Cloud Functions) doit avoir le **rôle minimal** (`secretmanager.versions.access` sur un sous-ensemble de secrets, pas `secretmanager.admin` projet).
+5. **ReCaptcha** : `google/recaptcha` configuré — vérifier que la validation backend est obligatoire et non bypass-able (clé secret stockée correctement).
+6. **Pas d'OAuth/SSO** côté serveur RCQ (Firebase délègue) → tâche **retirée** du template.
+7. **Pas de password storage côté RCQ** (Firebase gère) → tâche **retirée** du template.
+
+### Wave 3 — Surface HTTP & headers
+1. **CSP** : ajouter une politique stricte adaptée à AngularJS (besoin de `'unsafe-inline'` pour le bootstrap + `style-src 'self' 'unsafe-inline'`, `script-src 'self'`, `connect-src 'self' https://*.googleapis.com https://www.google.com/recaptcha/`). Tester en **report-only** d'abord en dev.
+2. **HSTS** : `Strict-Transport-Security: max-age=31536000; includeSubDomains` — vérifier que Cloud Run ne le pose pas déjà (sinon doublon inoffensif).
+3. **Referrer-Policy** : `strict-origin-when-cross-origin`.
+4. **Permissions-Policy** : minimum (`camera=(), microphone=(), geolocation=(self)` car le scan QR utilise la caméra → vérifier).
+5. **Rate limiting** : nginx `limit_req_zone` sur `/rest/login`, `/rest/registration`, `/rest/queteur/registration/approveQueteur` (anti brute-force + anti-spam d'inscription). Le module `ngx_http_limit_req_module` est dispo par défaut.
+6. **CORS** : si tout est même origine, ajouter explicitement `add_header Access-Control-Allow-Origin "$http_origin" always;` UNIQUEMENT pour `graph.redcrossquest.com` si ce subdomain consomme l'API. Sinon **pas de CORS du tout** (plus sûr).
+7. **Input validation** : `ClientInputValidatorSpecs` existe déjà ; auditer la couverture sur toutes les routes (corollaire de `composer check:routes` ajouté en commit récent).
+
+### Wave 4 — Données & accès
+1. **SQL injection** : confirmer que **100% des requêtes PDO** utilisent des paramètres bindés (`:name`, `?`). Grep des `->query(` vs `->prepare(` + interpolation `"$variable"` dans les SQL.
+2. **IDOR / authorisation horizontale** : chaque route doit filtrer par `ulId` issu du JWT, pas du body/URL. Re-vérifier `getQueteurById`, `getTroncQueteurById`, `getULById`, etc.
+3. **Authorisation verticale** : `AuthorisationMiddleware` filtre déjà par `roleId` vs path — bon. Mais re-confirmer après la régression `ul_settings` fixée récemment (commit `7ba68b7`) qu'aucun champ sensible ne fuit pour `roleId=1`.
+4. **Logging PII/secrets** : audit des `$this->logger->error(...)` qui passent des `$queteurEntity` ou `$messageProperties` — risque de fuite RGPD (email, mobile, NIVOL, birthdate dans les logs Cloud Logging). Définir une whitelist de champs loggables.
+5. **RGPD anonymisation** : `AnonymizeQueteur` existe — vérifier qu'il anonymise bien tous les champs PII (notes, email, mobile, birthdate, NIVOL) et que les backups/exports BigQuery suivent.
+6. **PubSub payloads** : cf. `docs/pubsub_messages.md` — les 3 topics actifs publient des `QueteurEntity` et `TroncQueteurEntity` **complètes** (incluant email, mobile, NIVOL, birthdate). Vérifier que les abonnés (Cloud Functions + BigQuery sinks) sont dans le périmètre RGPD et que les topics ont DLP scanning si possible.
+
+### Wave 5 — CI/CD & infra (introductive)
+1. **Introduire un workflow GitHub Actions minimal** :
+   - `composer-audit.yml` : `composer audit --locked` sur PRs et chaque semaine sur master.
+   - `npm-audit.yml` : `npm audit --audit-level=high` côté `client/`.
+   - `dependabot.yml` : config groupée (npm devDep / npm dep / composer), auto-merge des `patch` uniquement après tests.
+   - **Toutes les actions `uses:` doivent être pinnées par SHA 40-char** (anti `tj-actions`).
+2. **`permissions:` explicites** sur chaque workflow (`contents: read` par défaut).
+3. **Branch protection sur `master`** : review obligatoire (déjà le cas ?), status checks `composer-audit` et `npm-audit` obligatoires, no force push.
+4. **Cloud Run** :
+   - Service account dédié par service avec rôles minimaux (Cloud SQL Client, Secret Manager Accessor sur secrets précis, PubSub Publisher sur 3 topics seulement).
+   - `--ingress=internal-and-cloud-load-balancing` à évaluer si on utilise un load balancer + Cloud Armor.
+   - Container : user non-root dans `docker/php-fpm/Dockerfile`, `readOnlyRootFilesystem` si compatible avec PHP (tmp dirs à monter).
+5. **Cloud Armor** (optionnel) : règle anti-OWASP préconfigurée + rate limit IP-based en complément de nginx.
+6. **Audit IAM cross-project** (rcq-fr-prod ↔ rq-fr-prod) : les Cloud Functions ont besoin d'accès cross-project — vérifier qu'aucun rôle `editor`/`owner` global n'est attribué (cf. `GCP/init_lib/common.sh`).
+
+---
+
+## 4. Hors scope explicite
+
+- **`/Users/tom/Projects/rcq-functions-v2/`** : audit séparé à planifier dans ce repo (stack Python 3.13, Cloud Functions Gen2). Le présent plan ne couvre que les Cloud Functions Gen1 héritées dans RCQ (toujours via `GCP/deploy_cloudFunctions.sh`).
+- **Migration AngularJS → framework moderne** : projet à part entière (cf. `docs/frontend_upgrade_audit.md`), traité ici uniquement par **mitigation** (CSP, audit deps, accepter le risque).
+- **Migration MySQL → autre** : pas dans cet audit.
+- **Pentest applicatif externe** : ce plan est un audit *internal review* + supply chain, pas un test d'intrusion.
+
+---
+
+## 5. Démarrage
+
+Quand l'utilisateur donne le go :
+1. **Wave 0** d'abord (~30 min, zéro modif code, juste capture du baseline).
+2. **STOP** → présenter résultats Wave 0 + plan Wave 1 ajusté → attendre approbation.
+3. **Wave 1** : une PR par groupe de fix (1 PR composer + 1 PR npm + 1 PR forks GitHub).
+4. Pour les waves suivantes : présenter chaque wave, demander approbation, exécuter.
+
+**Règle dérivée du template, durcie pour RCQ** : **aucune modif prod sans dev+test d'abord**. Les changements CSP/CORS/rate-limiting doivent être déployés en `dev` puis observés ≥ 24h avant `test`, idem avant `prod`.

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -1,0 +1,218 @@
+# Audit sécurité — supply chain + hardening classique
+
+Ce document est un **prompt prêt à coller** pour lancer un audit sécurité complet sur un projet logiciel. Il couvre deux volets : attaques supply chain (npm/PyPI/GitHub Actions, y compris les compromissions récentes Shai-Hulud, nx, chalk/Qix, tj-actions, xz-utils) et hardening classique (auth, secrets, CORS, headers, injection, autorisation, CI/CD).
+
+**Comment l'utiliser** : créer un nouveau workspace Intent sur le repo cible, coller ce fichier (ou son contenu) au coordinator, remplir les 3 placeholders du bloc « Contexte projet », puis laisser le coordinator faire la phase Recon et planifier les waves. Le coordinator ne code pas lui-même : il délègue à des implementors et fait vérifier par des verifiers.
+
+---
+
+## Contexte projet
+- **Repo** : <chemin local ou URL git>
+- **Stack** : <ex: Node/Angular + Python/FastAPI + MySQL, ou autre — laisse vide pour auto-détection>
+- **Environnements** : <local, dev, test, prod — décris brièvement comment ils sont déployés>
+
+## Objectif
+Faire un audit sécurité complet en deux volets :
+1. **Supply chain** — détecter et corriger toute dépendance compromise, obsolète ou vulnérable, et durcir l'intégrité des lockfiles.
+2. **Hardening classique** — corriger les vulnérabilités courantes (auth, secrets, CORS, headers, injection, validation, etc.).
+
+Tu es **Coordinator**. Tu planifies, délègues à des implementors, vérifies. Tu **n'écris pas de code toi-même**. Tu utilises des **waves** (vague d'implémentation → vérification → vague suivante).
+
+## Phase 1 — Recon (toi, sans déléguer)
+
+Avant de planifier, recense :
+- Lockfiles présents : `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `poetry.lock`, `Pipfile.lock`, `requirements.txt`, `go.sum`, `Cargo.lock`, `composer.lock`, etc.
+- Gestionnaires de secrets : `.env`, `.env.example`, fichiers Terraform, GitHub Actions secrets référencés.
+- Frameworks d'auth en place (JWT, OAuth, sessions, cookies).
+- Surface réseau : routes API publiques, CORS config, reverse proxy, headers HTTP.
+- CI/CD : workflows GitHub Actions / GitLab CI / autre — vérifier pinning des actions tierces.
+
+Lance ces commandes (lecture seule) :
+```bash
+# Node
+npm audit --json 2>/dev/null | head -200
+npm ls --all 2>&1 | head -50
+
+# Python
+poetry show --outdated 2>/dev/null || pip list --outdated
+pip-audit 2>/dev/null || safety check 2>/dev/null
+
+# Secrets dans le repo (sans logger les valeurs)
+git log --all -p | grep -iE "(api[_-]?key|secret|password|token|bearer)" | head -20
+
+# Lockfile drift
+git diff HEAD -- '*.lock' 'package-lock.json' 2>&1 | head -20
+```
+
+Liste ensuite ce que tu trouves dans le Spec **sans révéler de valeurs secrètes** (uniquement les noms de fichiers / paquets / advisories).
+
+## Phase 1.5 — Attaques supply chain connues à vérifier explicitement
+
+Pour chaque attaque ci-dessous, l'implementor DOIT vérifier que le repo n'est pas affecté (lockfile + arbre de dépendances transitives) et documenter le résultat dans le Spec.
+
+### npm — 2025
+
+**Shai-Hulud worm** (septembre 2025)
+- Worm npm auto-réplicant qui vole les tokens des maintainers et republie les paquets compromis.
+- Plus de 500 paquets touchés sur plusieurs vagues.
+- IoCs : présence du fichier `bundle.js` malveillant, scripts `postinstall` exfiltrant `~/.npmrc`, `~/.aws`, `~/.config/gh`, variables d'env.
+- Cibles connues incluent des paquets de `@ctrl/*`, `@nativescript-community/*`, `@crowdstrike/*`, plus rebonds via tokens volés.
+- Commandes de vérif :
+  ```bash
+  # Chercher les versions affectées dans le lockfile (liste à mettre à jour selon advisory GitHub)
+  npm ls --all 2>&1 | grep -iE "@ctrl/tinycolor|@nativescript-community"
+  # Vérifier qu'aucun postinstall n'exfiltre quoi que ce soit
+  find node_modules -name "package.json" -exec grep -l "postinstall" {} \; | head
+  ```
+
+**s1ngularity / nx attack** (août 2025)
+- `nx` et plusieurs plugins (`@nx/*`, `@nrwl/*`) compromis.
+- Versions malveillantes : `nx@20.9.0`, `21.5.0`, `21.6.0`, `21.7.0`, `21.8.0`, et plugins associés sur la même fenêtre.
+- IoCs : script `telemetry.js` exfiltrant tokens GitHub/npm.
+- Vérif : `npm ls nx @nx/* @nrwl/* 2>&1 | grep -v "deduped"`.
+
+**chalk / debug / qix maintainer** (septembre 2024, toujours d'actualité dans les vieux lockfiles)
+- Le maintainer Qix s'est fait phisher, ~20 paquets compromis pendant ~2h : `chalk`, `debug`, `ansi-styles`, `strip-ansi`, `color-convert`, `color-name`, `wrap-ansi`, `supports-color`, `is-arrayish`, `error-ex`, `simple-swizzle`, `has-ansi`, `ansi-regex`, `slice-ansi`.
+- Versions malveillantes spécifiques (ex: `chalk@5.6.1`, `debug@4.4.2`). Liste exacte : GitHub Security Advisory `GHSA-...`.
+- Vérif : `npm audit` + scan manuel des hashes.
+
+### npm — 2024 et avant
+- **lottie-player** (octobre 2024) — `@lottiefiles/lottie-player` compromis.
+- **ua-parser-js** (2021) — versions `0.7.29`, `0.8.0`, `1.0.0` malveillantes.
+- **node-ipc** (mars 2022) — protestware effaçant des fichiers.
+- **event-stream** (2018) — historique mais à vérifier sur vieux projets.
+
+### PyPI
+- **xz-utils backdoor** (CVE-2024-3094, mars 2024) — versions `5.6.0` et `5.6.1` de `xz`/`liblzma`. Pas Python directement mais affecte tout container basé sur Debian/Ubuntu non patché.
+- **ctx** et **phpass** (mai 2022) — paquets typosquattés.
+- **colorama / fake colorama** — typosquatting récurrent.
+- Vérif générique : `pip-audit` + `safety check` + `grep -r "atexit.register" site-packages | head` pour détecter des exfiltrations.
+
+### Actions GitHub
+- **tj-actions/changed-files** (mars 2025) — compromis, exfiltrait les secrets dans les logs publics.
+- Vérif : `grep -r "tj-actions" .github/workflows/` et confirmer pinning par SHA, pas par tag.
+- Plus généralement : tout `uses: <author>/<action>@v...` sans SHA est à reprendre.
+
+### Tâches Spec correspondantes (à ajouter en Wave 1, en plus des génériques)
+
+@@@task
+# Scan Shai-Hulud + worms npm récents
+## Scope
+Vérifier que le lockfile n'inclut aucune version compromise par Shai-Hulud (sept 2025), s1ngularity/nx (août 2025), Qix/chalk (sept 2024), tj-actions, lottie-player, ua-parser-js, node-ipc.
+## Definition of Done
+- Liste exhaustive des paquets vérifiés (nom + version installée + statut: SAFE / COMPROMISED / UPGRADED).
+- Tout paquet compromis : upgrade vers la version safe + audit des secrets potentiellement exfiltrés (rotation tokens npm/GitHub/cloud si compromission confirmée).
+- Document dans le Spec section "Supply chain scan results".
+## Verification
+- `npm audit --audit-level=moderate` clean.
+- `git log --all -p -- package-lock.json` n'introduit pas de versions blacklistées.
+- Pour les actions GitHub : tous les `uses:` pointent vers un SHA 40-char.
+@@@
+
+@@@task
+# Rotation tokens si compromission détectée
+## Scope
+Si la tâche précédente a trouvé un paquet compromis QUI A ÉTÉ INSTALLÉ (pas juste dans le lockfile mais exécuté en CI ou en local par un dev), rotation immédiate de :
+- Tokens npm (CI + locaux des maintainers).
+- Tokens GitHub (PAT, app tokens).
+- Tokens cloud référencés dans les env du CI ou des shells des dev.
+- Cookies de session des services intégrés.
+## Definition of Done
+- Liste des tokens identifiés à risque (par fichier/CI, sans révéler les valeurs).
+- Confirmation utilisateur qu'ils ont été rotés (l'agent ne tourne PAS les tokens lui-même).
+## Verification
+- Documenter dans le Spec : `Token X : rotated YYYY-MM-DD`.
+@@@
+
+@@@task
+# Audit postinstall scripts (toutes deps)
+## Scope
+Lister tous les scripts `preinstall`, `install`, `postinstall` dans `node_modules/*/package.json` et dans `package.json` racine + workspaces. Identifier ceux qui font des accès réseau ou lisent des fichiers sensibles (`~/.npmrc`, `~/.aws`, `~/.ssh`, `~/.config/gh`).
+## Definition of Done
+- Liste des scripts trouvés + verdict (legit / suspect / malveillant).
+- Pour les suspects : analyse manuelle.
+- Recommandation : activer `npm config set ignore-scripts true` côté CI si possible.
+## Verification
+- Pas d'exfiltration détectée dans les scripts.
+@@@
+
+**Notes complémentaires sur la Phase 1.5** :
+- La liste évolue vite — l'implementor doit aussi consulter `https://github.com/advisories?query=type%3Areviewed+ecosystem%3Anpm` et `https://osv.dev/list` au moment où il bosse, plus les dernières 4 semaines de news GitHub Security Lab.
+- Shai-Hulud est en premier vu que c'est l'attaque la plus récente et la plus virulente (auto-réplication).
+- Le pattern « rotation tokens » est critique : si un dev a `npm install` sur une version compromise, ses creds sont potentiellement leakées même si on retire ensuite le paquet du lockfile.
+
+## Phase 2 — Plan (Spec note, format `@@@task`)
+
+Crée une **tâche par catégorie** dans le Spec. Ordre suggéré (par criticité) :
+
+### Wave 1 — Supply chain (CRITIQUE)
+- `@@@task` **Lockfile integrity audit** — vérifier qu'aucun lockfile n'a été modifié hors PR, comparer les hashes intégrité (`integrity` field dans `package-lock.json`).
+- `@@@task` **Compromised packages scan** — chercher les paquets connus comme compromis récemment (consulter advisories npm/PyPI/etc., GitHub Security Advisories, `osv.dev`). Lister chaque hit. Voir aussi les 3 tâches dédiées de la Phase 1.5.
+- `@@@task` **High/Critical CVEs** — `npm audit`, `pip-audit`, `cargo audit`, etc. Fixer ou justifier chaque high/critical.
+- `@@@task` **Dependency pinning** — vérifier que les versions sont pinnées (pas de `^` ou `~` agressifs sur les deps sensibles : auth, crypto, http server). Pour les actions GitHub : pin par SHA, pas par tag.
+- `@@@task` **Renovate/Dependabot config** — vérifier la config (groupage, auto-merge limité, fenêtres de release).
+
+### Wave 2 — Auth & secrets
+- `@@@task` **Audit secrets management** — aucun secret hardcodé, `.env` gitignored, `.env.example` à jour. Vérifier rotation possible.
+- `@@@task` **JWT/session hardening** — si JWT : algo `RS256` ou `HS256` avec secret ≥ 256 bits, `exp` court, refresh tokens si applicable. Vérifier `iss`, `aud`, `nbf`. Cookies : `HttpOnly`, `Secure`, `SameSite=Lax` ou `Strict`.
+- `@@@task` **OAuth/SSO callbacks** — valider `state`, `redirect_uri` whitelist exacte, PKCE pour SPAs publics.
+- `@@@task` **Password storage** (si applicable) — bcrypt/argon2 avec coût adéquat, pas de MD5/SHA1.
+
+### Wave 3 — Surface réseau & HTTP
+- `@@@task` **CORS** — pas de `*` en prod, origines explicites par env, `credentials: true` uniquement si nécessaire.
+- `@@@task` **Security headers** — `Strict-Transport-Security`, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY` ou CSP `frame-ancestors`, `Referrer-Policy`, `Content-Security-Policy` adapté.
+- `@@@task` **Rate limiting** — sur les endpoints d'auth et coûteux (export, search).
+- `@@@task` **Input validation** — Pydantic/Zod/Joi sur toutes les entrées API, validation longueur/format.
+
+### Wave 4 — Données & accès
+- `@@@task` **SQL injection** — aucun query string concaténée, uniquement params bindés (`text(...)` avec params nommés en SQLAlchemy, prepared statements).
+- `@@@task` **Authorization checks** — vérifier que chaque endpoint contrôle le rôle/scope (pas seulement l'authentification).
+- `@@@task` **IDOR** — vérifier que les `id` dans les URLs sont validés contre l'utilisateur courant (ex: `/api/users/{id}` doit refuser un id qui n'appartient pas à l'utilisateur, sauf admin).
+- `@@@task` **Logging** — pas de secrets/tokens/PII dans les logs ; logs d'audit pour les actions sensibles.
+
+### Wave 5 — CI/CD & infra
+- `@@@task` **GitHub Actions pinning** — `uses: actions/checkout@<sha>` partout, pas `@v4`.
+- `@@@task` **Permissions workflows** — `permissions:` explicites, principe du moindre privilège (`contents: read` par défaut).
+- `@@@task` **Branch protection** — review requise, status checks obligatoires, no force push sur `main`.
+- `@@@task` **Container/Cloud Run** — image base minimale (`distroless`, `alpine`), non-root user, `readOnlyRootFilesystem` si possible. Secrets via Secret Manager, pas via env vars en clair dans les manifestes.
+
+## Phase 3 — Exécution
+
+Pour chaque wave :
+1. STOP, présente le plan au user, attend l'approbation.
+2. Délègue **toutes les tâches de la wave en parallèle** avec `waitMode: "after_all"` et `specialist: "implementor"`.
+3. END TURN, attends la complétion de toute la wave.
+4. Délègue un `specialist: "verifier"` qui relit les diffs et confirme.
+5. Merge les PRs (une par tâche, ou une PR par wave si tu préfères — décide avec l'user).
+
+## Règles strictes
+
+- **Une PR par fix** (sauf petits fixes regroupés explicitement).
+- **Tests** : chaque PR doit ajouter ou garder verts les tests existants.
+- **Branches** : `security/<wave>-<short-desc>` (ex: `security/wave1-npm-audit`).
+- **Cible** : `main` (ou `master` selon le repo).
+- **Squash merge** par défaut.
+- **Jamais de secret en clair** dans les commits, PR body, ou logs (même temporaires).
+- **Prod en dernier** : si un changement touche prod (CORS, headers), feature-flag d'abord, prod en dernière étape.
+- **Rollback plan** documenté dans chaque PR à risque (config infra, deps majeures).
+
+## Livrables attendus
+
+- Spec note maintenue à jour, une section par wave.
+- Une PR par tâche complétée, mergée et déployée en dev/test avant prod.
+- Rapport final : tableau `Catégorie | Avant | Après | Référence (CVE/PR)`.
+
+## Démarrage
+
+1. Renomme le workspace (3-5 mots, sentence case, ex: « Security audit projet X »).
+2. Fais la phase Recon.
+3. Écris le Spec avec toutes les tâches identifiées en `@@@task`.
+4. Présente le plan, demande l'approbation.
+5. Délègue Wave 1.
+
+## Notes d'utilisation de ce prompt
+
+- Remplace les 3 placeholders en haut (`<chemin>`, `<stack>`, `<environnements>`).
+- Si tu sais déjà quels paquets sont compromis sur la stack ciblée, ajoute-les explicitement dans la Phase 1.5 avant de démarrer.
+- Adapte les waves selon la stack : si pas d'OAuth, retire la sous-tâche correspondante.
+- Tu peux retirer des waves entières si déjà faites sur ce projet.


### PR DESCRIPTION
## Docs only - PubSub inventory + Security audit plan

Two atomic commits, all under `docs/`.

### 1. `docs: add PubSub messages inventory` (`5da0763`)
Maps the 3 active Pub/Sub topics published by the PHP backend
(`tronc_queteur_create`, `tronc_queteur_update`, `queteur_approval_topic`)
plus the orphan topic `ul_update` declared in `settings.php` but never
published from anywhere (confirmed by code search across both
RedCrossQuest and rcq-functions-v2). For each topic: emitter file,
payload schema, message attributes, business purpose, downstream
consumers.

Includes a reliability note: all PHP publishes wrap the call in a
try/catch that swallows the exception (`//do not rethrow`) - this is
intentional so the cashier flow is not blocked by a Pub/Sub outage,
but it means no retry queue, no DLQ. Documented as future hardening.

### 2. `docs: add security audit template and RCQ-contextualized plan` (`ebafcde`)
- `security-audit.md`: generic prompt-style audit template covering
  supply chain (Shai-Hulud Sep 2025, nx Aug 2025, Qix/chalk Sep 2024,
  xz-utils CVE-2024-3094, tj-actions Mar 2025) and classic hardening
  (auth, secrets, CORS, headers, injection, IDOR, CI/CD).
- `security-audit-rcq.md`: the same plan applied to this codebase.
  Pre-filled recon section (56 Dependabot alerts confirmed at push,
  no `.github/workflows/`, JWT HS256, nginx headers partial - HSTS/CSP
  missing). 5 waves adapted: Supply chain, Auth & Secrets, HTTP
  surface, Data & access (incl. RGPD on PubSub payloads which contain
  PII), CI/CD bootstrap.
  Out of scope: Cloud Functions Gen2 (`rcq-functions-v2` - separate
  repo, separate audit), AngularJS migration, external pentest.

### Status
- Targeted scan already executed against Shai-Hulud / Qix / xz-utils:
  **CLEAN on all three** (results to be appended to the audit doc when
  Wave 1 runs).
- No code changes in this PR, only documentation.

### Stats
3 files, +442 / -0.
