### PR TITLE
security(deps): bump phpseclib/phpseclib 3.0.51 -> 3.0.52 (CVE-2026-44167)

### DIFF
--- a/server/composer.lock
+++ b/server/composer.lock
@@ -4334,16 +4334,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.51",
+            "version": "3.0.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748"
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d59c94077f9c9915abb51ddb52ce85188ece1748",
-                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
                 "shasum": ""
             },
             "require": {
@@ -4424,7 +4424,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.51"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
             },
             "funding": [
                 {
@@ -4440,7 +4440,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T01:33:53+00:00"
+            "time": "2026-04-27T07:02:15+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
## Wave 1 / B1 — phpseclib 3.0.51 → 3.0.52

Single-package security bump, transitive dep.

### Vulnerability
- **CVE-2026-44167** / GHSA-3qpq-r242-jqj7
- Severity: **HIGH** (CVSS 7.5, CWE-400)
- Description: CVE-2024-27355 mitigation bypass — OID amplification
  DoS in `ASN1::decodeOID()` when loading untrusted ASN.1 files
  (X.509 certs, RSA PKCS8 keys, etc.).
- Affects: `>= 3.0.0, <= 3.0.51`
- Fix: `3.0.52`

### Dependency chain
`google/apiclient v2.19.2` requires `phpseclib/phpseclib ^3.0.50`,
which 3.0.52 satisfies. Patch bump, no API surface change.

### Validation
- `composer audit` (post-update): **No security vulnerability
  advisories found.**
- `composer audit:php85` (phpstan + phpcs:compat + check:routes):
  same **42 pre-existing phpstan errors** on `master` and on this
  branch, **none mentioning phpseclib**. No regression.

### Scope
- `server/composer.lock` only (+6 / -6).
- No `composer.json` change (constraint already satisfied).

### Dependabot
- Closes alert **#288**.

### Audit progress
- Wave 0 baseline: 1 composer alert (HIGH) — this PR.
- After merge: composer audit clean. **0 alert restante côté PHP.**
- Remaining Wave 1 buckets: B2 axios chain (15 npm high), B3 gulp
  toolchain (lodash/minimist crit + 7 others), B4 jquery 2 → 3
  (4 medium, regression risk), B5 swagger-ui-dist (2 medium), B7
  gulp-ng-annotate devDep (5 crit).
