### PR TITLE
security(deps): bump jquery ^2.2.4 -> ^3.7.1 (XSS, proto pollution)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -28,7 +28,7 @@
         "angular-ui-bootstrap": "^2.5.6",
         "animate.css": "^4.1.1",
         "bootstrap-sass": "^3.4.3",
-        "jquery": "^2.2.4",
+        "jquery": "^3.7.1",
         "malarkey": "^1.3.3",
         "moment": "^2.29.4",
         "moment-timezone": "^0.5.45",
@@ -7233,10 +7233,9 @@
       "license": "MIT"
     },
     "node_modules/jquery": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-      "integrity": "sha512-lBHj60ezci2u1v2FqnZIraShGgEXq35qCzMv4lITyHGppTnA13rwR0MgwyNJh9TnDs3aXUvd1xjAotfraMHX/Q==",
-      "deprecated": "This version is deprecated. Please upgrade to the latest version or find support at https://www.herodevs.com/support/jquery-nes.",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "license": "MIT"
     },
     "node_modules/js-tokens": {

--- a/client/package.json
+++ b/client/package.json
@@ -74,7 +74,7 @@
     "angular-ui-bootstrap": "^2.5.6",
     "animate.css": "^4.1.1",
     "bootstrap-sass": "^3.4.3",
-    "jquery": "^2.2.4",
+    "jquery": "^3.7.1",
     "malarkey": "^1.3.3",
     "moment": "^2.29.4",
     "moment-timezone": "^0.5.45",


### PR DESCRIPTION
## Wave 1 / B4 — jquery `^2.2.4` → `^3.7.1`

Direct front-end dep bump. Resolves the `jquery <=3.4.1` advisories:

- **CVE-2019-11358** — prototype pollution via `$.extend(true, …)`
- **CVE-2020-11022** / **CVE-2020-11023** — XSS via HTML-like input
  passed to jQuery DOM manipulation methods
- **CVE-2020-7656** — XSS in `$.parseHTML` (IE < 11)

### Target choice — why 3.7.1, not 4.x
- AngularJS 1.8.x officially supports **jQuery 3.x** (replaces jqLite
  with full jQuery at bootstrap when present).
- `angular-ui-bootstrap@2.5.6` supports jQuery 3.x.
- jQuery 4.0 (Oct 2024) drops IE/old-browser shims and changes a few
  APIs — out of scope and not required to clear advisories.

### Regression risk assessment
Greppable removed/deprecated 2.x APIs in `client/src/` — **all clean**:
```
$.browser, $.boxModel, $.support
.live(), .die(), .toggle(fn,fn), .size(), .andSelf()
.load()/.unload()/.error() event shorthands
$.parseHTML(htm, ctx, true)
[selected] attr selectors
$.parseJSON / $.isArray / $.trim / $.now
```
No usage found. Safe to ship.

### Validation
```
npm audit pre-B4  : 0 low / 6 mod / 8 high / 4 crit = 18
npm audit post-B4 : 0 low / 5 mod / 8 high / 4 crit = 17
                     0     -1       0       0       = -1
```
jquery no longer appears in advisories.

### Scope
- `client/package.json`: `jquery ^2.2.4 → ^3.7.1`
- `client/package-lock.json`: regenerated (one line bump)

### Smoke test recommendation
Manual smoke test recommended post-deploy (datepicker, modal,
typeahead, dropdowns from angular-ui-bootstrap).
