### PR TITLE
security(deps): bump swagger-ui-dist ^3.25.0 -> ^5.32.6 (SSRF, spoofing)

### DIFF
--- a/server/openapi/package-lock.json
+++ b/server/openapi/package-lock.json
@@ -1,13 +1,32 @@
 {
   "name": "openapi",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "swagger-ui-dist": {
-      "version": "3.25.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.25.0.tgz",
-      "integrity": "sha512-vwvJPPbdooTvDwLGzjIXinOXizDJJ6U1hxnJL3y6U3aL1d2MSXDmKg2139XaLBhsVZdnQJV2bOkX4reB+RXamg=="
+  "packages": {
+    "": {
+      "name": "openapi",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "swagger-ui-dist": "^5.32.6"
+      }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.6",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.6.tgz",
+      "integrity": "sha512-75ttZNaYCLoFPnozPZcTUU6mS3wKT8l7WLjU5zJSHFeJa23i5vtnze6IiCl4jDMPeQTXVXIgovq4M11NNfQvSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
     }
   }
 }

--- a/server/openapi/package.json
+++ b/server/openapi/package.json
@@ -9,6 +9,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "swagger-ui-dist": "^3.25.0"
+    "swagger-ui-dist": "^5.32.6"
   }
 }


### PR DESCRIPTION
## Wave 1 / B5 — swagger-ui-dist `^3.25.0` → `^5.32.6`

Direct dep bump in `server/openapi/`. Resolves both Dependabot
medium alerts:

| GHSA | severity | summary | fixed in |
|---|---|---|---|
| GHSA-6c9x-mj3g-h47x | medium | Spoofing attack in swagger-ui-dist | 4.1.3 |
| GHSA-qrmm-w75w-3wpx | medium | Server-side request forgery in SwaggerUI | 4.1.3 |

### Target choice — why 5.x
- 4.1.3 is the minimum to clear advisories.
- 5.x is the current major line — iso-functional for our use case
  (static rendering of `rcq-openapi.yaml`).
- The package only ships static HTML/JS/CSS assets copied from
  `node_modules/swagger-ui-dist/` by `run_swagger.sh`; **dev-only
  tool**, not part of the Cloud Run image or production runtime.

### Side effect
`server/openapi/package-lock.json` migrates from `lockfileVersion: 1`
(npm 5) to `lockfileVersion: 3` (npm 9+) as a regeneration artifact.

### Validation
- `npm audit` (server/openapi/): **0 vulnerabilities found**.
- `run_swagger.sh` behaviour unchanged (loads
  `node_modules/swagger-ui-dist/index.html`, swaps URL to
  `rcq-openapi.yaml`).

### Scope
- `server/openapi/package.json` (+1 / -1)
- `server/openapi/package-lock.json` (regenerated, +26 / -7)
