### PR TITLE
security(deps): close gulp-ng-annotate chain criticals via minimist+merge overrides

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8134,9 +8134,9 @@
       }
     },
     "node_modules/merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+      "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -8674,13 +8674,6 @@
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
       }
-    },
-    "node_modules/optimist/node_modules/minimist": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/client/package.json
+++ b/client/package.json
@@ -91,6 +91,8 @@
     "send": "^0.19.2",
     "serve-static": "^1.16.3",
     "lodash": "^4.17.21",
-    "globule": "^1.3.4"
+    "globule": "^1.3.4",
+    "minimist": "^1.2.8",
+    "merge": "^2.1.1"
   }
 }


### PR DESCRIPTION
## Wave 1 / B7 — gulp-ng-annotate chain criticals

Closes the last critical advisories carried by the unmaintained
build toolchain:

```
gulp-ng-annotate@2.1.0          (latest on npm)
  └── ng-annotate@1.2.2
        └── optimist@0.6.1
              └── minimist@0.0.10   ← CVE-2020-7598 proto pollution
  └── merge@<2.1.1                  ← proto pollution
```

`gulp-ng-annotate@2.1.0` is the **latest version on npm** — no
upstream fix path exists, and `npm audit` proposes a "BREAKING
fix → 0.2.0" which is a multi-year downgrade. Instead, override
the actual vulnerable roots in the chain:

| package | old (deepest) | new | severity |
|---|---|---|---|
| minimist | 0.0.10 | ^1.2.8 | **critical** |
| merge | <2.1.1 | ^2.1.1 | high |

Once `minimist` is upgraded, the chain advisories on `optimist`,
`ng-annotate`, `gulp-ng-annotate` ("depend on vulnerable versions
of minimist") and the lodash criticality flag dissolve automatically.

### Validation
```
npm audit pre-B7  : 0 low / 5 mod / 8 high / 4 crit = 17
npm audit post-B7 : 0 low / 5 mod / 7 high / 0 crit = 12
                     0     0       -1       -4    = -5
```

### **0 critical remain on the client/ side.**

### Remaining 12 advisories (post-B7)
All unfixable legacy or accepted-risk:
- `gulp@3.9.1`, `gulp-util`, `gulp-htmlmin`, `html-minifier`,
  `lodash.template`, `gulp-sourcemaps` + `postcss 7` — legacy gulp
  build toolchain, **devDep accepted risk**
- `angular`, `angular-audio`, `angular-sanitize`,
  `angular-qr-scanner-updated` — AngularJS 1.8.3 EOL (B6,
  accepted, Wave 3 CSP mitigation planned)

### Scope
- `client/package.json`: +2 / 0 (extends `overrides` block)
- `client/package-lock.json`: regenerated (-11 / -2 pruned dupes)
