### PR TITLE
feat(security): email validation warning on home page

### DIFF
--- a/client/src/app/components/emailValidation/emailValidation.service.js
+++ b/client/src/app/components/emailValidation/emailValidation.service.js
@@ -1,0 +1,56 @@
+/**
+ * Validates that a logged-in user's email is a personal Croix-Rouge address.
+ *
+ * Rules:
+ *  - must end with @croix-rouge.fr
+ *  - must NOT match any of the forbidden patterns below (generic/role-based
+ *    addresses that are not tied to a single volunteer).
+ *
+ * The list is intentionally kept simple and is expected to evolve.
+ */
+angular
+  .module('redCrossQuestClient')
+  .factory('EmailValidationService', function(){
+
+    var DOMAIN_REGEX = /@croix-rouge\.fr$/i;
+
+    // Email local parts are typically ASCII so accented variants ("trésori")
+    // rarely exist in mailboxes but are kept for safety.
+    var FORBIDDEN_PATTERNS = [
+      /(trésori|tresori)/i,
+      /presiden/i,
+      /^dt[0-9]{2}@/i,
+      /logistique/i,
+      /^ul\./i,
+      /uniforme/i
+    ];
+
+    var instance = {};
+
+    instance.isValidCroixRougeEmail = function(email)
+    {
+      if (email == null || typeof email !== 'string' || email.length === 0)
+      {
+        return false;
+      }
+
+      var trimmed = email.trim().toLowerCase();
+
+      if (!DOMAIN_REGEX.test(trimmed))
+      {
+        return false;
+      }
+
+      for (var i = 0; i < FORBIDDEN_PATTERNS.length; i++)
+      {
+        if (FORBIDDEN_PATTERNS[i].test(trimmed))
+        {
+          return false;
+        }
+      }
+
+      return true;
+    };
+
+    return instance;
+  });

--- a/client/src/app/components/emailValidation/emailValidation.service.spec.js
+++ b/client/src/app/components/emailValidation/emailValidation.service.spec.js
@@ -1,0 +1,83 @@
+(function() {
+  'use strict';
+
+  describe('service EmailValidationService', function() {
+    var EmailValidationService;
+
+    beforeEach(module('redCrossQuestClient'));
+    beforeEach(inject(function(_EmailValidationService_) {
+      EmailValidationService = _EmailValidationService_;
+    }));
+
+    it('should be registered', function() {
+      expect(EmailValidationService).not.toEqual(null);
+      expect(EmailValidationService.isValidCroixRougeEmail).toEqual(jasmine.any(Function));
+    });
+
+    describe('isValidCroixRougeEmail', function() {
+
+      it('accepts a personal croix-rouge.fr address', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('jean.dupont@croix-rouge.fr')).toBe(true);
+      });
+
+      it('accepts mixed case and trims', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('  Jean.Dupont@Croix-Rouge.FR  ')).toBe(true);
+      });
+
+      it('does not match the "presiden" prefix inside an unrelated word', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('presence.medicale@croix-rouge.fr')).toBe(true);
+      });
+
+      it('rejects empty/null/undefined', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('')).toBe(false);
+        expect(EmailValidationService.isValidCroixRougeEmail(null)).toBe(false);
+        expect(EmailValidationService.isValidCroixRougeEmail(undefined)).toBe(false);
+        expect(EmailValidationService.isValidCroixRougeEmail(42)).toBe(false);
+      });
+
+      it('rejects non croix-rouge.fr domain', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('jdoe@gmail.com')).toBe(false);
+        expect(EmailValidationService.isValidCroixRougeEmail('jdoe@croix-rouge.com')).toBe(false);
+        expect(EmailValidationService.isValidCroixRougeEmail('jdoe@something-croix-rouge.fr.evil.com')).toBe(false);
+      });
+
+      it('rejects tresori*/trésori* role mailboxes (both ASCII and accented)', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('tresorier75@croix-rouge.fr')).toBe(false);
+        expect(EmailValidationService.isValidCroixRougeEmail('trésorier75@croix-rouge.fr')).toBe(false);
+        expect(EmailValidationService.isValidCroixRougeEmail('tresoriere.ul@croix-rouge.fr')).toBe(false);
+      });
+
+      it('rejects presiden* role mailboxes', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('president.ul123@croix-rouge.fr')).toBe(false);
+        expect(EmailValidationService.isValidCroixRougeEmail('presidente@croix-rouge.fr')).toBe(false);
+      });
+
+      it('rejects dtXX@ DT generic mailboxes', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('dt75@croix-rouge.fr')).toBe(false);
+        expect(EmailValidationService.isValidCroixRougeEmail('dt06@croix-rouge.fr')).toBe(false);
+      });
+
+      it('accepts addresses that only contain dt[0-9]{2} but not at the start of local part', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('jean.dt75@croix-rouge.fr')).toBe(true);
+      });
+
+      it('rejects logistique mailboxes', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('logistique.idf@croix-rouge.fr')).toBe(false);
+      });
+
+      it('rejects ul.* generic mailboxes', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('ul.paris15@croix-rouge.fr')).toBe(false);
+        expect(EmailValidationService.isValidCroixRougeEmail('ul.nice@croix-rouge.fr')).toBe(false);
+      });
+
+      it('accepts a name that contains "ul" but is not the ul.* generic pattern', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('paul.dupont@croix-rouge.fr')).toBe(true);
+      });
+
+      it('rejects uniforme mailboxes', function() {
+        expect(EmailValidationService.isValidCroixRougeEmail('uniforme@croix-rouge.fr')).toBe(false);
+        expect(EmailValidationService.isValidCroixRougeEmail('uniforme.idf@croix-rouge.fr')).toBe(false);
+      });
+    });
+  });
+})();

--- a/client/src/app/main/main.controller.js
+++ b/client/src/app/main/main.controller.js
@@ -7,7 +7,8 @@
 
   /** @ngInject */
   function MainController($timeout, $localStorage, $scope, $rootScope,
-                          toastr, SettingsResource, PointQueteService)
+                          toastr, SettingsResource, PointQueteService,
+                          EmailValidationService)
   {
     var vm = this;
 
@@ -22,6 +23,8 @@
     vm.deploymentType = $localStorage.currentUser.d;
     vm.currentUserRole= $localStorage.currentUser.roleId;
 
+    vm.emailWarning   = false;
+    vm.userEmail      = '';
 
     //load in local storage the list of points de quete
     //used in preparationQuete for autocomplete
@@ -33,6 +36,8 @@
     {
       $localStorage.guiSettings = settings;
       vm.first_name = $localStorage.guiSettings.user.first_name;
+      vm.userEmail  = $localStorage.guiSettings.user.email || '';
+      vm.emailWarning = !EmailValidationService.isValidCroixRougeEmail(vm.userEmail);
       $rootScope.$emit('title-updated', 'Bienvenue '+vm.first_name);
     });
 

--- a/client/src/app/main/main.controller.spec.js
+++ b/client/src/app/main/main.controller.spec.js
@@ -58,5 +58,68 @@
       // populates it, so we assert the type only.
       expect(angular.isArray(vm.awesomeThings)).toBeTruthy();
     });
+
+    it('should initialise emailWarning to false and userEmail to empty before getAllSettings resolves', function() {
+      expect(vm.emailWarning).toBe(false);
+      expect(vm.userEmail).toEqual('');
+    });
+  });
+
+  // Separate suite to exercise the resolved-promise code path of getAllSettings:
+  // we provide a real $q-backed promise so the .then() callback runs after $apply().
+  describe('MainController email validation', function() {
+    var $controller, $rootScope, $localStorage;
+
+    beforeEach(module('redCrossQuestClient'));
+    beforeEach(module('client'));
+
+    function buildSpecForEmail(emailValue) {
+      module(function($provide) {
+        $localStorage = {
+          currentUser: { username: 'u', ulName: 'ul', ulId: 1, d: 'D', roleId: 1 }
+        };
+        $provide.value('$localStorage', $localStorage);
+        $provide.value('PointQueteService', { loadPointQuete: function() {} });
+        $provide.factory('SettingsResource', function(_$q_) {
+          return {
+            getAllSettings: function() {
+              return { $promise: _$q_.when({ user: { first_name: 'Jean', email: emailValue } }) };
+            },
+            getSetupStatus: function() {
+              return { $promise: _$q_.when({}) };
+            }
+          };
+        });
+      });
+      inject(function(_$controller_, _$rootScope_) {
+        $controller = _$controller_;
+        $rootScope  = _$rootScope_;
+      });
+      var vm = $controller('MainController', { $scope: $rootScope.$new() });
+      $rootScope.$apply();
+      return vm;
+    }
+
+    it('does not warn for a valid croix-rouge.fr email', function() {
+      var vm = buildSpecForEmail('jean.dupont@croix-rouge.fr');
+      expect(vm.userEmail).toEqual('jean.dupont@croix-rouge.fr');
+      expect(vm.emailWarning).toBe(false);
+    });
+
+    it('warns for an external email', function() {
+      var vm = buildSpecForEmail('jean.dupont@gmail.com');
+      expect(vm.emailWarning).toBe(true);
+    });
+
+    it('warns for a forbidden role-based pattern (dtXX@)', function() {
+      var vm = buildSpecForEmail('dt75@croix-rouge.fr');
+      expect(vm.emailWarning).toBe(true);
+    });
+
+    it('warns when email is missing on user', function() {
+      var vm = buildSpecForEmail(null);
+      expect(vm.emailWarning).toBe(true);
+      expect(vm.userEmail).toEqual('');
+    });
   });
 })();

--- a/client/src/app/main/main.html
+++ b/client/src/app/main/main.html
@@ -23,6 +23,16 @@
     </div>
   </div>
 
+  <div class="row" ng-show="main.emailWarning" style="margin-bottom: 10px;">
+    <div class="col-md-10 col-md-offset-1">
+      <div class="alert alert-danger" role="alert">
+        <strong>Attention :</strong> Mettez à jour votre adresse email dans votre fiche queteur avec votre email Croix Rouge pour pouvoir accéder aux Graphiques de RedCrossQuest.<br/>
+        Utilisez votre email nominatif : <strong>prenom.nom@croix-rouge.fr</strong> (pas d'email de fonction)<br/>
+        Votre email est actuellement : <strong>{{main.userEmail}}</strong>
+      </div>
+    </div>
+  </div>
+
   <div class="row"
        style="margin-bottom: 10px;"
        ng-show="main.currentUserRole >= 4 && !(main.setupStatus.queteurIncomplete || main.setupStatus.userIncomplete || main.setupStatus.pointQueteIncomplete || main.setupStatus.dailyStatsIncomplete || main.setupStatus.troncsIncomplete) && !main.displayInstructions">

--- a/docs/security-audit-rcq.md
+++ b/docs/security-audit-rcq.md
@@ -24,14 +24,17 @@ Plan d'audit sécurité **contextualisé** au repo RedCrossQuest, dérivé du te
 | Élément | Valeur |
 |---|---|
 | Lockfiles | `client/package-lock.json`, `server/composer.lock`, `server/openapi/package-lock.json` |
-| Dependabot alerts (GitHub) | **56** (2 critical, 19 high, 29 moderate, 6 low) — confirmé au push de la PR #212 |
+| Dependabot alerts baseline (PR #212) | **56** (2 critical, 19 high, 29 moderate, 6 low) |
+| Dependabot alerts après Wave 1 (attendu post-scan) | **~17** — uniquement Angular EOL + legacy gulp 3.x devDep |
+| `composer audit` après Wave 1 | **clean** (0 advisory) |
+| `npm audit` (client/) après Wave 1 | **12** (0 crit / 7 high / 5 mod / 0 low) — 100 % legacy gulp + Angular EOL |
 | GitHub Actions | **aucun** workflow (à introduire en Wave 5) |
 | Dependabot/Renovate | non configuré |
 | JWT | HS256, secret symétrique en clair en RAM (`InMemory::plainText($jwtSecret)`), `iss`/`aud` validés |
 | Headers HTTP (nginx) | ✅ `X-Frame-Options DENY`, ✅ `X-Content-Type-Options nosniff`, ✅ `fastcgi_hide_header X-Powered-By` — ❌ **pas de HSTS, pas de CSP, pas de Referrer-Policy, pas de Permissions-Policy** |
 | CORS | aucune ligne `Access-Control-*` côté serveur ni nginx (front + back même origine via Cloud Run → OK par construction, à confirmer pour graph.redcrossquest.com) |
 | Postinstall scripts npm | non audité ; 2 deps GitHub-hosted (`dev-mansonthomas/angular-qr-updated`, `angular-qr-scanner-updated`) — fork perso, pinné par **tag** pas SHA |
-| Versions à risque connues | AngularJS 1.8.3 (EOL), jQuery 2.2.4 (CVE-2020-11022/23 sur `<2.2.0` mais reste vieux), bootstrap-sass 3.x (BS3 EOL), `angular-jwt@0.1.11` (10+ ans), Gen1 Cloud Functions (Node runtime ?). |
+| Versions à risque connues | AngularJS 1.8.3 (EOL), bootstrap-sass 3.x (BS3 EOL), `angular-jwt@0.1.11` (10+ ans), Gen1 Cloud Functions (Node runtime ?). *jQuery passé à 3.7.1 en B4.* |
 
 ---
 
@@ -131,53 +134,136 @@ Note : `gulp-ng-annotate` est en **devDep** uniquement (build pipeline). Les 5 �
 - ✅ La clé `ul_update_topic` a été retirée du `server/src/settings.php` local (Task B). `settings.php` étant gitignored et copié depuis `~/.cred/rcq-${COUNTRY}-${ENV}-settings.php` au déploiement, l'opérateur doit propager la même suppression dans les trois fichiers `~/.cred/rcq-fr-{dev,test,prod}-settings.php`. Voir `docs/pubsub_messages.md` section D.
 - 🟢 **Wave 1 prête à démarrer** : commencer par **B1 (phpseclib)** comme dry-run du process (1 paquet, fix mineur, faible risque).
 
-### Wave 1 — Supply chain (CRITIQUE)
-1. **Composer audit** : résoudre tous les `high`/`critical` sur `composer.lock`. Stack auth-critique : `lcobucci/jwt`, `firebase/php-jwt` transitif éventuel, `kreait/firebase-php`, `guzzlehttp/guzzle`, `symfony/http-client`.
-2. **npm audit `client/`** : prioriser les paquets touchant l'exécution navigateur (`angular*`, `jquery`, `bootstrap-sass`, `moment`, `zxcvbn`).
-3. **Phase 1.5 worms** : exécuter les 3 scans (Shai-Hulud / Qix / postinstall) sur `client/package-lock.json` et `server/openapi/package-lock.json`.
-4. **Forks GitHub** : `dev-mansonthomas/angular-qr-*` → pinner par **commit SHA** au lieu du tag (immuable). Vérifier que les forks n'ont pas dérivé de leur upstream pour autre chose qu'un bump.
-5. **Decision point** : AngularJS 1.8.3 EOL + jQuery 2.2.4. Le vrai fix = sortir d'AngularJS (projet hors scope, déjà documenté dans `docs/frontend_upgrade_audit.md`). À court terme : **accepter le risque documenté** et limiter la surface (CSP en Wave 3).
+### Wave 1 — Supply chain — ✅ **DONE (2026-05-18)**
 
-### Wave 2 — Auth, secrets, JWT
-1. **JWT** : HS256 acceptable tant que le secret est ≥ 256 bits et stocké uniquement en Secret Manager (déjà le cas). **À vérifier** : longueur effective du secret en prod (`gcloud secrets versions access` sans logger la valeur, juste `wc -c`).
-2. **JWT claims** : `exp` court, `iss`/`aud` validés (✅ dans `AuthorisationMiddleware`). Ajouter `nbf` si absent. Vérifier la **rotation** (qu'arrive-t-il si on change le secret en prod — tous les utilisateurs se reconnectent ?).
-3. **Firebase admin SDK** : `kreait/firebase-php` 7.18. Vérifier que les tokens RedQuest reçus côté Cloud Functions sont validés (signature + `aud` = projet GCP correct).
-4. **Secret Manager** : audit IAM. Chaque service account (Cloud Run runtime, CI futur, Cloud Functions) doit avoir le **rôle minimal** (`secretmanager.versions.access` sur un sous-ensemble de secrets, pas `secretmanager.admin` projet).
-5. **ReCaptcha** : `google/recaptcha` configuré — vérifier que la validation backend est obligatoire et non bypass-able (clé secret stockée correctement).
-6. **Pas d'OAuth/SSO** côté serveur RCQ (Firebase délègue) → tâche **retirée** du template.
-7. **Pas de password storage côté RCQ** (Firebase gère) → tâche **retirée** du template.
+#### Bilan d'exécution
 
-### Wave 3 — Surface HTTP & headers
-1. **CSP** : ajouter une politique stricte adaptée à AngularJS (besoin de `'unsafe-inline'` pour le bootstrap + `style-src 'self' 'unsafe-inline'`, `script-src 'self'`, `connect-src 'self' https://*.googleapis.com https://www.google.com/recaptcha/`). Tester en **report-only** d'abord en dev.
-2. **HSTS** : `Strict-Transport-Security: max-age=31536000; includeSubDomains` — vérifier que Cloud Run ne le pose pas déjà (sinon doublon inoffensif).
-3. **Referrer-Policy** : `strict-origin-when-cross-origin`.
-4. **Permissions-Policy** : minimum (`camera=(), microphone=(), geolocation=(self)` car le scan QR utilise la caméra → vérifier).
-5. **Rate limiting** : nginx `limit_req_zone` sur `/rest/login`, `/rest/registration`, `/rest/queteur/registration/approveQueteur` (anti brute-force + anti-spam d'inscription). Le module `ngx_http_limit_req_module` est dispo par défaut.
-6. **CORS** : si tout est même origine, ajouter explicitement `add_header Access-Control-Allow-Origin "$http_origin" always;` UNIQUEMENT pour `graph.redcrossquest.com` si ce subdomain consomme l'API. Sinon **pas de CORS du tout** (plus sûr).
-7. **Input validation** : `ClientInputValidatorSpecs` existe déjà ; auditer la couverture sur toutes les routes (corollaire de `composer check:routes` ajouté en commit récent).
+| Bucket | PR | Commit | Net advisories | Statut |
+|---|---|---|---|---|
+| **B1** — `phpseclib 3.0.51 → 3.0.52` (CVE-2026-44167) | [#215](https://github.com/dev-mansonthomas/RedCrossQuest/pull/215) | `82483b9` | composer audit −1 HIGH → **clean** | ✅ |
+| **B2** — `axios ≥ 0.31.1` via `overrides` (chaîne `angular-audio → browser-sync@2 → localtunnel → axios@0.21.4`) | [#216](https://github.com/dev-mansonthomas/RedCrossQuest/pull/216) | `80f6743` | npm 40 → 38 / Dependabot −15 HIGH | ✅ |
+| **B3** — toolchain gulp via 8 `overrides` (braces, micromatch, minimatch, semver, send, serve-static, lodash, globule) | [#217](https://github.com/dev-mansonthomas/RedCrossQuest/pull/217) | `8683dcb` | npm 38 → 18 (**−20**) | ✅ |
+| **B4** — `jquery ^2.2.4 → ^3.7.1` (XSS, proto pollution) | [#218](https://github.com/dev-mansonthomas/RedCrossQuest/pull/218) | `7d12cd6` | npm 18 → 17 (jquery cleared) | ✅ |
+| **B5** — `swagger-ui-dist ^3.25.0 → ^5.32.6` (SSRF, spoofing) | [#219](https://github.com/dev-mansonthomas/RedCrossQuest/pull/219) | `68b566d` | Dependabot −2 medium | ✅ |
+| **B6** — Angular 1.8.3 + lodash.template + angular-sanitize | — | — | **risque accepté** — pas de fix upstream (EOL), mitigation Wave 3 (CSP) | 🟡 |
+| **B7** — chaîne `gulp-ng-annotate` via overrides `minimist^1.2.8` + `merge^2.1.1` | [#220](https://github.com/dev-mansonthomas/RedCrossQuest/pull/220) | `cb83dbc` | npm 17 → 12 (**−4 critical, 0 restants**) | ✅ |
 
-### Wave 4 — Données & accès
-1. **SQL injection** : confirmer que **100% des requêtes PDO** utilisent des paramètres bindés (`:name`, `?`). Grep des `->query(` vs `->prepare(` + interpolation `"$variable"` dans les SQL.
-2. **IDOR / authorisation horizontale** : chaque route doit filtrer par `ulId` issu du JWT, pas du body/URL. Re-vérifier `getQueteurById`, `getTroncQueteurById`, `getULById`, etc.
-3. **Authorisation verticale** : `AuthorisationMiddleware` filtre déjà par `roleId` vs path — bon. Mais re-confirmer après la régression `ul_settings` fixée récemment (commit `7ba68b7`) qu'aucun champ sensible ne fuit pour `roleId=1`.
-4. **Logging PII/secrets** : audit des `$this->logger->error(...)` qui passent des `$queteurEntity` ou `$messageProperties` — risque de fuite RGPD (email, mobile, NIVOL, birthdate dans les logs Cloud Logging). Définir une whitelist de champs loggables.
-5. **RGPD anonymisation** : `AnonymizeQueteur` existe — vérifier qu'il anonymise bien tous les champs PII (notes, email, mobile, birthdate, NIVOL) et que les backups/exports BigQuery suivent.
-6. **PubSub payloads** : cf. `docs/pubsub_messages.md` — les 3 topics actifs publient des `QueteurEntity` et `TroncQueteurEntity` **complètes** (incluant email, mobile, NIVOL, birthdate). Vérifier que les abonnés (Cloud Functions + BigQuery sinks) sont dans le périmètre RGPD et que les topics ont DLP scanning si possible.
+**Décompte avant/après Wave 1 (npm audit `client/`)** :
+```
+avant : 2 low / 12 mod / 21 high / 5 critical  = 40 advisories
+après : 0 low /  5 mod /  7 high / 0 critical  = 12 advisories
+delta : −2     −7        −14       −5          = −28 advisories
+```
 
-### Wave 5 — CI/CD & infra (introductive)
-1. **Introduire un workflow GitHub Actions minimal** :
-   - `composer-audit.yml` : `composer audit --locked` sur PRs et chaque semaine sur master.
-   - `npm-audit.yml` : `npm audit --audit-level=high` côté `client/`.
-   - `dependabot.yml` : config groupée (npm devDep / npm dep / composer), auto-merge des `patch` uniquement après tests.
-   - **Toutes les actions `uses:` doivent être pinnées par SHA 40-char** (anti `tj-actions`).
-2. **`permissions:` explicites** sur chaque workflow (`contents: read` par défaut).
-3. **Branch protection sur `master`** : review obligatoire (déjà le cas ?), status checks `composer-audit` et `npm-audit` obligatoires, no force push.
-4. **Cloud Run** :
-   - Service account dédié par service avec rôles minimaux (Cloud SQL Client, Secret Manager Accessor sur secrets précis, PubSub Publisher sur 3 topics seulement).
-   - `--ingress=internal-and-cloud-load-balancing` à évaluer si on utilise un load balancer + Cloud Armor.
-   - Container : user non-root dans `docker/php-fpm/Dockerfile`, `readOnlyRootFilesystem` si compatible avec PHP (tmp dirs à monter).
-5. **Cloud Armor** (optionnel) : règle anti-OWASP préconfigurée + rate limit IP-based en complément de nginx.
-6. **Audit IAM cross-project** (rcq-fr-prod ↔ rq-fr-prod) : les Cloud Functions ont besoin d'accès cross-project — vérifier qu'aucun rôle `editor`/`owner` global n'est attribué (cf. `GCP/init_lib/common.sh`).
+**Décompte avant/après Wave 1 (`composer audit` server/)** :
+```
+avant : 1 advisory (phpseclib HIGH)
+après : 0 advisory (clean)
+```
+
+#### Resté ouvert après Wave 1 (= risque accepté)
+
+Les 12 advisories `npm audit` restantes sont **toutes** dans deux catégories pour lesquelles il n'existe **aucun fix upstream** :
+
+1. **Legacy gulp 3.x build toolchain (devDep, hors bundle navigateur)** — `gulp@3.9.1`, `gulp-util`, `gulp-htmlmin`, `html-minifier`, `lodash.template`, `gulp-sourcemaps` + `postcss@7` (`@gulp-sourcemaps/identity-map`). Ces paquets sont morts upstream (aucune release depuis 2019+). Le seul vrai fix = migrer hors de Gulp (gros chantier, hors scope sécu).
+2. **AngularJS 1.8.3 EOL** — `angular`, `angular-audio`, `angular-sanitize`, `angular-qr-scanner-updated` (fork perso). Mitigation : **CSP stricte en Wave 3** (réduit la surface XSS) + sortie d'AngularJS planifiée dans `docs/frontend_upgrade_audit.md` (hors scope sécu).
+
+#### Reporté (sera traité hors Wave 1)
+
+- **Forks GitHub pinning par SHA** (`dev-mansonthomas/angular-qr-updated`, `angular-qr-scanner-updated`) — déplacé dans **Wave 5 / supply chain housekeeping** (geste d'hygiène, faible risque, pas lié à une CVE active).
+- **Docker base images** : `node-client` est sur Debian 12 + bookworm via `node:22`. Pinning par digest à introduire dans **Wave 5 / CI/CD**.
+- **`composer audit --dev`** (incluant devDeps) — non exécuté en Wave 1 (le baseline était `--no-dev`). À faire en Wave 5 dans le workflow `composer-audit.yml`.
+
+### Wave 2 — Auth, secrets, JWT — 🟢 À FAIRE
+
+**Objectif** : durcir la chaîne d'authentification (JWT RCQ + Firebase + Secret Manager) et figer l'IAM GCP au principe du moindre privilège.
+
+**Périmètre code** :
+- `server/src/Middleware/AuthorisationMiddleware.php` (validation JWT + ACL par roleId)
+- `server/src/routes/routesActions/authentication/AuthenticateAction.php` (login RCQ)
+- `server/src/routes/routesActions/authentication/FirebaseAuthenticateAction.php` (login Firebase)
+- `server/src/Service/SecretManagerService.php` (accès Secret Manager)
+- `server/src/Service/ClientInputValidator/` (validation ReCaptcha)
+- `server/src/routes/00-authentication.php` (5 routes auth publiques)
+
+| # | Tâche | Effort | Critère de succès |
+|---|---|---|---|
+| **W2-1** | **Audit longueur secret JWT en prod** : `gcloud secrets versions access latest --secret=JWT_SECRET --project=rcq-fr-prod \| wc -c` (≥ 32 bytes = 256 bits). Idem dev/test. **Ne jamais logger la valeur.** | XS | Trois envs ≥ 32 bytes confirmés, document privé updaté. |
+| **W2-2** | **Claims JWT** : confirmer `exp` (≤ 8h ? à arbitrer), `iss`/`aud` validés (déjà OK dans `AuthorisationMiddleware`), ajouter `nbf` si absent. | S | Token décodé en test contient les 4 claims. |
+| **W2-3** | **Rotation secret JWT** : documenter la procédure (Secret Manager versioning + redeploy Cloud Run). Tester la rotation en `rcq-fr-dev` (tous les users actifs sont déconnectés, sans crash backend). | S | Runbook dans `docs/runbooks/jwt-rotation.md`. |
+| **W2-4** | **Firebase token validation** : `kreait/firebase-php@7.18` — vérifier dans `FirebaseAuthenticateAction` que `$auth->verifyIdToken()` est appelé (signature + `aud` = projet GCP correct, pas seulement parse). PHPStan signale déjà un type mismatch `$JWTConfiguration` ligne 78 (`docs/audit/phpstan.txt`:1655) — investiguer. | M | Test unitaire avec token forgé → rejeté. |
+| **W2-5** | **Audit IAM Secret Manager** : pour chaque SA (`rcq-fr-{dev,test,prod}-backend@…`, Cloud Functions SA, futur CI SA), grep `roles/secretmanager.*` → doit être `roles/secretmanager.secretAccessor` sur secrets **précis** (pas `admin` projet). Commande : `gcloud projects get-iam-policy rcq-fr-prod --flatten="bindings[].members" --filter="bindings.role:roles/secretmanager.*"`. | M | Tableau IAM par SA dans `docs/runbooks/iam-audit.md`. |
+| **W2-6** | **ReCaptcha v3 backend** : confirmer que `AuthenticateAction` rejette **systématiquement** si `ReCaptchaService::verify()` échoue (pas de fallback silencieux). PHPStan ligne 32 (`FirebaseAuthenticateAction::$reCaptchaService is never read`) → la prop est injectée mais jamais utilisée, **possible bypass**. | S | Trace de log explicite sur échec ReCaptcha, refactor pour utiliser la prop. |
+| **W2-7** | **Audit des 5 routes non authentifiées** (`/firebase-authenticate`, `/authenticate`, `/sendInit`, `/getInfoFromUUID/{uuid}`, `/resetPassword`, `/thanks_mailing`, `/ul_registration`) : confirmer rate-limit (W3-5) + validation input + protection anti-énumération sur `/getInfoFromUUID`. | M | Cf. allowlist nginx `docker/nginx/rcq-backend.conf:29`. |
+| **W2-8** | **Logging anti-fuite secrets** : grep des `$this->logger->error("...$tokenStr...")` ou similaire — confirmer qu'aucun secret n'est jamais loggé même en debug. | S | Grep clean. |
+| ~~OAuth/SSO~~ | Firebase délègue → tâche retirée du template. | — | — |
+| ~~Password storage~~ | Firebase gère côté front, backend RCQ ne stocke pas de mot de passe (sauf legacy `q_user.password` à confirmer) → vérifier algo (bcrypt/argon2) si présent. | S | Grep `password_hash` dans backend. |
+
+### Wave 3 — Surface HTTP & headers — 🟢 À FAIRE
+
+**Objectif** : durcir les headers HTTP côté nginx (Cloud Run) et brider les routes auth publiques contre le brute-force.
+
+**Périmètre code** :
+- `docker/nginx/rcq-backend.conf` (vhost backend, déjà `X-Frame-Options DENY` + `nosniff`)
+- `app.yaml` / config GAE équivalente côté front (à vérifier)
+- `server/src/Service/ClientInputValidator/ClientInputValidatorSpecs.php` (couverture validation)
+
+| # | Tâche | Effort | Critère de succès |
+|---|---|---|---|
+| **W3-1** | **CSP en report-only** sur `rcq-fr-dev` : `Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://*.googleapis.com https://www.google.com/recaptcha/ https://www.gstatic.com; frame-src https://www.google.com/recaptcha/; object-src 'none'; base-uri 'self'; report-uri /rest/csp-report;`. AngularJS 1.8.x requiert `'unsafe-eval'` (compilation templates) → impossible à éviter sans rewriter. | M | 0 violation CSP en navigation dev ≥ 48h. |
+| **W3-2** | **CSP enforce** sur `rcq-fr-test` puis `rcq-fr-prod`, après 1 semaine en report-only sans incident. | S | Même header sans le `-Report-Only`. |
+| **W3-3** | **HSTS** : `Strict-Transport-Security: max-age=31536000; includeSubDomains` dans `docker/nginx/rcq-backend.conf` (vérifier que Cloud Run/GFE ne le pose pas déjà — doublon inoffensif mais à confirmer). | XS | Header présent en réponse `curl -I`. |
+| **W3-4** | **Referrer-Policy** + **Permissions-Policy** : `Referrer-Policy: strict-origin-when-cross-origin`. `Permissions-Policy: camera=(self), microphone=(), geolocation=(), interest-cohort=()`. La caméra est nécessaire pour le scan QR (`angular-qr-scanner-updated`). | XS | Headers présents. |
+| **W3-5** | **Rate limiting nginx** : `limit_req_zone $binary_remote_addr zone=auth:10m rate=5r/m;` + `limit_req zone=auth burst=10 nodelay;` sur les 5 routes publiques (`/rest/authenticate`, `/rest/firebase-authenticate`, `/rest/sendInit`, `/rest/getInfoFromUUID`, `/rest/resetPassword`, `/rest/thanks_mailing`, `/rest/ul_registration`). Module `ngx_http_limit_req_module` dispo par défaut. | M | Test : `for i in $(seq 1 20); do curl -X POST .../authenticate; done` → 503 après 5. |
+| **W3-6** | **CORS** : front + back même origine via Cloud Run (`app.redcrossquest.com` / `*.appspot.com`) → **ne rien ajouter**. À confirmer pour `graph.redcrossquest.com` si ce subdomain appelle `/rest/`. Si oui, allowlist explicite (pas de `*`). | XS | `grep -r "Access-Control" docker/nginx/` clean ou allowlist précise. |
+| **W3-7** | **Input validation coverage** : `composer check:routes` confirme déjà que toutes les routes ont un `ClientInputValidatorSpecs`. Auditer manuellement les specs des 7 routes publiques (W2-7) — type, longueur max, regex, sanitization. | S | Toutes specs publiques ont `MaxLength` + `Regex` ou `Type` strict. |
+| **W3-8** | **CSP report endpoint** : `POST /rest/csp-report` → handler minimal qui log dans Cloud Logging (avec rate-limit pour éviter le DoS log). Optionnel mais utile pour W3-1. | S | Endpoint répond 204, log structuré. |
+
+### Wave 4 — Données & accès — 🟢 À FAIRE
+
+**Objectif** : confirmer l'absence d'injection SQL, d'IDOR/escalade horizontale, et minimiser l'exposition PII (logs, PubSub, BigQuery).
+
+**Périmètre code** :
+- `server/src/Service/*DBService.php` (toutes les classes `*DBService` = couche PDO)
+- `server/src/Middleware/AuthorisationMiddleware.php` (déjà filtre par `roleId`)
+- `server/src/routes/routesActions/**/*.php` (vérifier que `$ulId = $decodedJWT->getUlId();` est utilisé pour filtrer, pas `$args['ulId']`)
+- `server/src/Service/AnonymizeQueteur.php`
+- `server/src/Service/PubSubService.php` + 3 topics actifs (`mailing`, `mailing_status`, `queteur_anonymization`)
+
+| # | Tâche | Effort | Critère de succès |
+|---|---|---|---|
+| **W4-1** | **SQL injection sweep** : `grep -rn "->query(" server/src/Service/` (vs `->prepare()`), `grep -rEn '"\\\$[a-zA-Z]' server/src/Service/*DBService.php` (interpolation dans SQL). Toute query non préparée → réécrire en bindings. | M | Grep clean, ou ticket pour chaque cas légitime (rare). |
+| **W4-2** | **IDOR horizontal** : pour chaque route lisant un `id` queteur/tronc/ul depuis l'URL ou le body, vérifier que la query ajoute `AND ulId = :ulIdFromJWT`. Lister les routes concernées via `composer check:routes`. | L | Tableau route → check ulId dans `docs/audit/idor.md`. |
+| **W4-3** | **Escalade verticale post-`ul_settings`** : `AuthorisationMiddleware` filtre par path/roleId (commit `7ba68b7` a corrigé une régression). Re-tester manuellement pour `roleId=1` (queteur de base) sur les routes admin (`/rest/9/...`, `/rest/8/...`). | S | 0 route admin accessible à roleId=1. |
+| **W4-4** | **Logging PII/secrets** : grep `$this->logger->error/warning/info` qui passent un `$queteurEntity`, `$user`, `$messageProperties`, body brut → risque RGPD (email, mobile, NIVOL, birthdate visibles dans Cloud Logging). Définir whitelist (id, ulId, roleId, action). | M | Refactor + tests, plus aucun PII dans les logs. |
+| **W4-5** | **AnonymizeQueteur** : vérifier que **tous** les champs PII sont anonymisés (notes, email, mobile, birthdate, NIVOL, firstName, lastName). Vérifier qu'aucune table secondaire (`q_user_action_history`, BigQuery sinks) ne conserve les valeurs originales après anonymisation. | M | Test unitaire `AnonymizeQueteur` couvre tous les champs. |
+| **W4-6** | **PubSub payloads minimaux** : actuellement (cf. `docs/pubsub_messages.md`) les 3 topics publient `QueteurEntity`/`TroncQueteurEntity` **complets** (PII inclus). Évaluer s'il est possible de ne publier que `{ulId, queteurId, actionType}` + un fetch séparé côté subscriber. Sinon vérifier que les subscribers/sinks BigQuery sont DPA-conformes. | L | Décision documentée, et si réduction possible, schéma minimisé. |
+| **W4-7** | **DLP scanning PubSub** : activer `Cloud DLP` sur les 3 topics si réduction (W4-6) impossible. Alternative : encryption au niveau application avec CMEK. | M | Job DLP planifié, alertes configurées. |
+
+### Wave 5 — CI/CD & infra — 🟢 À FAIRE
+
+**Objectif** : introduire un gating CI minimal (composer/npm audit en bloquant) et durcir l'IAM/runtime GCP.
+
+**Périmètre code** :
+- `.github/workflows/` (à créer)
+- `.github/dependabot.yml` (à créer)
+- `docker/php-fpm/Dockerfile`, `docker/node/Dockerfile`, `docker/nginx/Dockerfile`
+- `GCP/init_lib/common.sh`, `GCP/deploy_back.sh`, `GCP/deploy_cloudFunctions.sh`
+
+| # | Tâche | Effort | Critère de succès |
+|---|---|---|---|
+| **W5-1** | **`composer-audit.yml`** : sur PR et hebdo sur master, `composer install --no-dev` + `composer audit --locked` + `composer audit:php85` (phpstan, phpcs:compat, check:routes). Fail si nouvelle alerte HIGH+. **Actions pinnées par SHA 40-char**. `permissions: contents: read`. | M | Workflow vert, bloque les PRs introduisant une CVE HIGH. |
+| **W5-2** | **`npm-audit.yml`** : sur PR et hebdo, `cd client && npm ci && npm audit --audit-level=high --omit=dev`. Idem `server/openapi/`. Idem actions pinnées + permissions minimales. | M | Workflow vert. |
+| **W5-3** | **`gulp-build.yml`** : `cd client && npm ci && npx gulp build` pour valider que les overrides Wave 1 ne cassent pas la build (validation que les smoke tests B3/B4 passent). | S | Build vert. |
+| **W5-4** | **`.github/dependabot.yml`** : ecosystem `composer` (server/), `npm` (client/, server/openapi/), `docker` (docker/*/Dockerfile), `github-actions` (.github/workflows/). Groupes : `npm-devDep`, `npm-dep`, `composer-direct`, `composer-transitive`. Auto-merge **patch uniquement** après CI verte. | S | Renovate-style PRs hebdo. |
+| **W5-5** | **Branch protection `master`** : review obligatoire ≥ 1, status checks `composer-audit` / `npm-audit` / `gulp-build` requis, pas de force push, pas de bypass admin. | XS | Settings GitHub appliqués. |
+| **W5-6** | **Pin GitHub-hosted forks par SHA** (reporté de Wave 1) : `angular-qr-updated#v1.0.1` → `angular-qr-updated#<commit-sha>`. Idem `angular-qr-scanner-updated`. Auditer le diff du fork vs upstream. | S | `client/package.json` pinné par SHA. |
+| **W5-7** | **Pin Docker base images par digest** : `node:22 → node:22@sha256:...`, `php:8.5-fpm-bookworm → php:8.5-fpm-bookworm@sha256:...`, `nginx:*-alpine → ...@sha256:...`. Renovate gère le bump auto. | S | Images pinnées dans 3 Dockerfiles. |
+| **W5-8** | **Cloud Run IAM least-privilege** : pour chaque service Cloud Run (`back`, `front`, `fb`), SA dédié avec **uniquement** `roles/cloudsql.client`, `roles/secretmanager.secretAccessor` sur secrets précis, `roles/pubsub.publisher` sur 3 topics. Pas d'`editor`/`owner`/`viewer` projet. | M | Tableau IAM par service dans `docs/runbooks/iam-audit.md`. |
+| **W5-9** | **Cloud Run runtime hardening** : user non-root dans `docker/php-fpm/Dockerfile` (`USER 1000:1000`), `readOnlyRootFilesystem` si compatible PHP-FPM (volumes `tmpfs` pour `/tmp`, `/var/log/...`). Évaluer `--ingress=internal-and-cloud-load-balancing` si Cloud Armor adopté. | M | Container démarre en non-root, tests E2E verts. |
+| **W5-10** | **Cloud Armor** (optionnel) : policy anti-OWASP préconfigurée + rate-limit IP (complète W3-5 qui agit par instance). | M | Politique attachée au Load Balancer. |
+| **W5-11** | **Audit IAM cross-project** : `rcq-fr-prod` ↔ `rq-fr-prod` (Cloud Functions Gen1 accèdent à des ressources cross-project). Vérifier `GCP/init_lib/common.sh` — aucun rôle `editor`/`owner` global. | S | Tableau cross-project dans `docs/runbooks/iam-audit.md`. |
+| **W5-12** | **Reactiver `composer audit --dev`** dans le workflow `composer-audit.yml` (W5-1 le fait déjà mais à expliciter — couvre les devDeps `phpstan`, `phpcs`, `phpunit` si réintroduit, etc.). | XS | Workflow audit complet. |
 
 ---
 

--- a/server/src/DBService/UserDBService.php
+++ b/server/src/DBService/UserDBService.php
@@ -233,9 +233,9 @@ LIMIT 1
     }
 
     $sql = "
-SELECT u.id, u.queteur_id, LENGTH(u.password) >1 as password_defined, u.role, 
+SELECT u.id, u.queteur_id, LENGTH(u.password) >1 as password_defined, u.role,
        u.nb_of_failure, u.last_failure_login_date, u.last_successful_login_date,
-       u.init_passwd_date, u.active, u.created, u.updated, u.nivol, q.first_name, q.last_name
+       u.init_passwd_date, u.active, u.created, u.updated, u.nivol, q.first_name, q.last_name, q.email
 FROM   users u, queteur q
 WHERE  u.id = :id
 AND    q.id = u.queteur_id

--- a/server/src/Entity/UserEntity.php
+++ b/server/src/Entity/UserEntity.php
@@ -91,8 +91,13 @@ class UserEntity extends Entity
    * @var ?string $last_name last name of the user
    */
   public ?string $last_name                   ;
+  /**
+   * @OA\Property()
+   * @var ?string $email email of the queteur attached to this user (joined from queteur table)
+   */
+  public ?string $email                       ;
 
-  protected array $_fieldList = ['id','nivol','queteur_id','password','password_defined','role','created','updated','active','last_failure_login_date','nb_of_failure','last_successful_login_date','init_passwd_date','first_name','last_name'];
+  protected array $_fieldList = ['id','nivol','queteur_id','password','password_defined','role','created','updated','active','last_failure_login_date','nb_of_failure','last_successful_login_date','init_passwd_date','first_name','last_name','email'];
   /**
    * Accept an array of data matching properties of this class
    * and create the class
@@ -122,5 +127,6 @@ class UserEntity extends Entity
 
     $this->getString ('first_name'                , $data, 100);
     $this->getString ('last_name'                 , $data, 100);
+    $this->getEmail  ('email'                     , $data);
   }
 }


### PR DESCRIPTION
## Summary

Adds a client-side check on login that detects users connected with a non-personal / non-Croix-Rouge email and displays a red alert above the **Afficher les instructions** button, inviting them to update their queteur record.

Also bundles the previously approved Wave-2-to-5 update of `docs/security-audit-rcq.md` (separate commit).

---

## Validation rules (client-side only)
- Domain must match `@croix-rouge.fr` (case-insensitive)
- Local part must NOT match any of:
  - `trésori` / `tresori` (accented + ASCII forms)
  - `presiden`
  - `^dt[0-9]{2}@` (generic DT mailboxes — `dt75@…`, `dt92@…`)
  - `logistique`
  - `^ul\.` (UL functional mailboxes)
  - `uniforme`

Rules are encapsulated in `EmailValidationService` so the list can evolve with a single-file edit.

## Message displayed

> **Attention :** Mettez à jour votre adresse email dans votre fiche queteur avec votre email Croix Rouge pour pouvoir accéder aux Graphiques de RedCrossQuest.
> Utilisez votre email nominatif : **prenom.nom@croix-rouge.fr** (pas d'email de fonction)
> Votre email est actuellement : **{{main.userEmail}}**

Visible to **all roles** (no gating).

## Backend exposure
`UserDBService::getUserInfoWithUserId` now also selects `q.email`, and `UserEntity` exposes it through the existing `getAllSettings` flow (stored in `$localStorage.guiSettings.user`). **No JWT change**, no auth-scope impact.

## Scope
| File | Type |
|---|---|
| `server/src/DBService/UserDBService.php` | SELECT + 1 column |
| `server/src/Entity/UserEntity.php` | +`?string $email` property |
| `client/src/app/components/emailValidation/emailValidation.service.js` | **new** factory |
| `client/src/app/components/emailValidation/emailValidation.service.spec.js` | **new** — 14 specs |
| `client/src/app/main/main.controller.js` | inject service, set `vm.emailWarning` / `vm.userEmail` |
| `client/src/app/main/main.controller.spec.js` | +4 specs (resolved-`$q` path) |
| `client/src/app/main/main.html` | `.alert-danger` block above the instructions button |
| `docs/security-audit-rcq.md` | Waves 2-5 detailed plan |

## Tests
```
gulp test → 30 SUCCESS / 0 failure / 0 lint warning
gulp build → OK (app bundle 468 → 469 kB)
php -l UserEntity.php UserDBService.php → OK
phpstan → no new errors on touched files
```

## Out of scope (deferred)
- No server-side enforcement (Wave 2 will revisit auth/JWT/secrets).
- Email is not added to JWT claims.
- Rules list stays as code; no admin UI to edit it.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author