### PR TITLE
release(2026.0): bump RCQVersion and add 2026 changelog entry

### DIFF
--- a/client/src/app/changelog/changelog.html
+++ b/client/src/app/changelog/changelog.html
@@ -49,7 +49,26 @@ ROLE       : {{cl.currentUserRole}}</pre>
         <div class="col-md-8">
 
           <uib-accordion close-others="false">
-            <div uib-accordion-group class="panel-default" heading="Version 2025" is-open="true">
+            <div uib-accordion-group class="panel-default" heading="Version 2026" is-open="true">
+              <ul>
+                <li><b>Interface Graphique (ce site web quoi...) :</b>
+                  <ol>
+                    <li>Nouveaux Graphiques ! L'accès aux anciens graphiques a été coupé sans sommation, ce qui a demandé un énorme travail pour reconstruire très rapidement une solution de remplacement</li>
+                    <li>Les graphiques utilisent l'authentification Google Workspace avec le compte prenom.nom@croix-rouge.fr ! Pensez à mettre a jour votre email dans votre fiche quêteur. Un message d'avertissement apparait sur la page d'accueil si votre email n'est pas un email @croix-rouge.fr</li>
+                    <li>RedQuest : Amélioration des performances, correctifs de sécurités</li>
+                    <li>Nombreuses mise à jour de sécurité</li>
+                  </ol>
+                </li>
+                <li><b>Coté Serveur :</b>
+                  <ol>
+                    <li>Mise à jour de sécurités</li>
+                    <li>Réécriture de la partie Serveur de RedQuest</li>
+                    <li>Nouveau Serveur pour les graphiques</li>
+                  </ol>
+                </li>
+              </ul>
+            </div>
+            <div uib-accordion-group class="panel-default" heading="Version 2025" is-open="false">
               <ul>
                 <li><b>Interface Graphique (ce site web quoi...) :</b>
                   <ol>

--- a/server/src/dependencies.php
+++ b/server/src/dependencies.php
@@ -73,7 +73,7 @@ return function (ContainerBuilder $containerBuilder)
     "RCQVersion" => function ():string
     {
       //version stays here, so that I don't have to update all the settings files
-      return "2025.0";
+      return "2026.0";
     },
     /**
      * Custom Logger that automatically add context data to each log entries.


### PR DESCRIPTION
## Summary

Releases version **2026.0**:
- bumps `RCQVersion` `2025.0 → 2026.0` in `server/src/dependencies.php`
- adds the **Version 2026** entry to the changelog UI (`client/src/app/changelog/changelog.html`), open by default; **Version 2025** is collapsed.

## 2026 highlights (user-facing)

### Interface Graphique
- **Nouveaux Graphiques** — l'accès aux anciens graphiques a été coupé sans sommation, ce qui a demandé un énorme travail pour reconstruire très rapidement une solution de remplacement
- Les graphiques utilisent l'authentification **Google Workspace** avec le compte `prenom.nom@croix-rouge.fr`. Pensez à mettre à jour votre email dans votre fiche quêteur. Un message d'avertissement apparaît sur la page d'accueil si votre email n'est pas un email `@croix-rouge.fr`
- **RedQuest** : amélioration des performances, correctifs de sécurité
- Nombreuses mises à jour de sécurité

### Coté Serveur
- Mises à jour de sécurité
- Réécriture de la partie serveur de RedQuest
- Nouveau serveur dédié pour les graphiques

## Scope
| File | Change |
|---|---|
| `server/src/dependencies.php` | `RCQVersion` `2025.0` → `2026.0` |
| `client/src/app/changelog/changelog.html` | nouvelle entrée Version 2026 + close Version 2025 |

No build/test impact: pure text/version bump.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author