### PR TITLE
chore(logs): reduce prod log noise + document QR code validation rejects

### DIFF
--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,42 @@
+# TODO
+
+Liste des chantiers identifiés et différés. À implémenter quand l'occasion se présente.
+
+---
+
+## DB invariants — CHECK constraints sur les colonnes `nivol`
+
+**Contexte.** Le NIVOL (identifiant Croix-Rouge volontaire) doit toujours être :
+- en **majuscules** (`UPPER(nivol) = nivol`)
+- **sans espaces** ni autre whitespace en début/fin (`TRIM(nivol) = nivol`)
+
+Le code applicatif (PHP) repose aujourd'hui sur cet invariant sans le garantir au niveau base. Une analyse de prod (mai 2026) a révélé 7 lignes `queteur` avec un espace en fin de nivol, vestige d'un import en 2018. Données nettoyées via `UPDATE ... SET nivol = TRIM(nivol)`.
+
+**Pourquoi pas un fix PHP ?** Les writes côté PHP n'ont pas produit de donnée sale depuis 2018, donc patcher chaque `insert`/`update` ajouterait du `strtoupper(trim(ltrim(...)))` partout sans bénéfice empirique. Une contrainte DB est plus chirurgicale.
+
+**À implémenter** via une migration Phinx (`server/db/migrations/YYYYMMDDHHMMSS_NivolCheckConstraints.php`) :
+
+```sql
+ALTER TABLE queteur
+  ADD CONSTRAINT chk_queteur_nivol_clean
+  CHECK (nivol = UPPER(nivol) AND nivol = TRIM(nivol));
+
+ALTER TABLE users
+  ADD CONSTRAINT chk_users_nivol_clean
+  CHECK (nivol = UPPER(nivol) AND nivol = TRIM(nivol));
+```
+
+**Pré-requis** avant migration :
+1. Vérifier que les 3 envs (dev/test/prod) sont propres :
+   ```sql
+   SELECT COUNT(*) FROM queteur WHERE nivol != UPPER(nivol) OR LENGTH(nivol) != LENGTH(TRIM(nivol));
+   SELECT COUNT(*) FROM users   WHERE nivol != UPPER(nivol) OR LENGTH(nivol) != LENGTH(TRIM(nivol));
+   ```
+2. Si lignes trouvées : `UPDATE ... SET nivol = UPPER(TRIM(nivol)) WHERE ...` avant l'ALTER.
+3. Tester sur dev puis test avant prod.
+
+**Compatibilité MariaDB.** Les CHECK constraints sont enforced depuis MariaDB 10.2.1 (2016). Vérifier la version cible (`SELECT VERSION()`).
+
+**Comportement attendu après migration.** Toute tentative d'`INSERT`/`UPDATE` violant la contrainte échouera avec une `SQLSTATE[23000]` côté PHP. Le code applicatif `UserDBService::insert/updateNivol` et `QueteurDBService::insert/update` devra alors uppercaser/trimmer en amont — c'est précisément l'effet recherché (forcer la propreté à la source).
+
+---

--- a/server/src/DBService/DBService.php
+++ b/server/src/DBService/DBService.php
@@ -120,15 +120,18 @@ abstract class DBService
       $this->logger->error("error while executeQueryForObject", ["sql"=>$sql, "parameters"=>$parameters, Logger::$EXCEPTION=>$e]);
       throw $e;
     }
-    $message = "SQL query return 0 rows instead of 1";
     if($throwExceptionIfNotFound)
     {
+      $message = "SQL query return 0 rows instead of 1";
       $this->logger->error($message, ["sql"=>$sql, "parameters"=>$parameters]);
       throw new Exception($message);
     }
     else
     {
-      $this->logger->warning($message, ["sql"=>$sql, "parameters"=>$parameters]);
+      //caller opted-in to handle 0-row result by passing throwExceptionIfNotFound=false
+      //logged at INFO (not WARNING) so it doesn't pollute alerting
+      $this->logger->info("SQL query returned 0 rows (expected, caller handles null)",
+        ["sql"=>$sql, "parameters"=>$parameters]);
       return null;
     }
   }

--- a/server/src/routes/routesActions/authentication/SendPasswordInitializationMailAction.php
+++ b/server/src/routes/routesActions/authentication/SendPasswordInitializationMailAction.php
@@ -81,7 +81,7 @@ class SendPasswordInitializationMailAction extends Action
     }
     catch(Exception $e)
     {
-      $this->logger->warning("sendInit : Error while setting UUID for user with specified username",
+      $this->logger->warning("sendInit : user with specified username doesn't exist",
         array(
           "passedLogin"=>$username,
           Logger::$EXCEPTION=>$e));
@@ -95,11 +95,6 @@ class SendPasswordInitializationMailAction extends Action
       $this->emailBusinessService->sendInitEmail($queteur, $uuid);
       $this->logger->debug("sendInit: mail with uuid sent ", array('username' => $username, 'uuid'=>$uuid));
 
-    }
-    else
-    {//the user do not have an account
-      $this->logger->info("sendInit: user do not have an account ", array('username' => $username));
-      //Send identical response
     }
     $this->response->getBody()->write(json_encode(new SendPasswordInitializationMailResponse(true)));
     return $this->response;

--- a/server/src/routes/routesActions/queteurs/ListQueteurs.php
+++ b/server/src/routes/routesActions/queteurs/ListQueteurs.php
@@ -56,6 +56,15 @@ class ListQueteurs extends Action
       return $this->response;
     }
 
+    // Note sur 'q' (recherche par id/nom/nivol) et 'queteurIds' (liste d'id séparés
+    // par des virgules pour la recherche QR multi-queteurs) :
+    // Ces deux champs sont fréquemment alimentés par un scan de QR code décodé côté
+    // JS dans le navigateur (sans appel serveur). Les lecteurs QR peuvent produire
+    // des chaînes aberrantes en cas de mauvaise lecture (caractères parasites, ids
+    // numériques fantaisistes, longueurs incohérentes). Les bornes (maxLength 100)
+    // et les rejets de validation associés sont volontaires : ils filtrent le bruit
+    // du scanner. Les WARNING 'Input value fails validations' avec actionClass=
+    // ListQueteurs sur ces paramètres sont donc attendus.
     $validations = [
       ClientInputValidatorSpecs::withInteger('pageNumber'         , $this->queryParams, 100 , false    ),
       ClientInputValidatorSpecs::withInteger('rowsPerPage'        , $this->queryParams, 100 , false    ),

--- a/server/src/routes/routesActions/troncs/ListTroncs.php
+++ b/server/src/routes/routesActions/troncs/ListTroncs.php
@@ -43,6 +43,14 @@ class ListTroncs extends Action
    */
   protected function action(): Response
   {
+    // Note sur le paramètre 'q' (préfixe de recherche par id de tronc) :
+    // Le formulaire de recherche est alimenté par un scan QR code décodé côté JS
+    // dans le navigateur (sans appel serveur). Les lecteurs QR peuvent produire des
+    // chaînes numériques aberrantes en cas de mauvaise lecture (ex: q=76457645 alors
+    // que max(tronc.id) ~= 7605). La borne max à 1 000 000 est volontairement très
+    // au-dessus des id réels et sert de garde-fou : elle rejette le bruit du scanner
+    // au lieu d'envoyer une requête SQL inutile. Les rejets logués en WARNING avec
+    // actionClass=ListTroncs sont donc attendus et ne traduisent pas un bug.
     $this->validateSentData(
       [
         ClientInputValidatorSpecs::withInteger('pageNumber'  , $this->queryParams, 100     , false    ),


### PR DESCRIPTION
## Contexte

Suite à l'analyse des logs prod de mai 2026 (~2000 WARNING/28h, 1 ERROR), 3 sources de bruit identifiées et corrigées. Aucun bug fonctionnel — uniquement de l'hygiène de logs et de la doc.

## Changements

### `DBService::executeQueryForObject` — WARNING → INFO
Quand le caller passe `throwExceptionIfNotFound=false`, il opt-in explicitement pour gérer un résultat null. Logger un WARNING contredit ce contrat.
- Downgrade WARNING → INFO + message clarifié `"SQL query returned 0 rows (expected, caller handles null)"`
- **Supprime ~536 faux warnings / 28h en prod** (la source principale du bruit)

### `SendPasswordInitializationMailAction` — reformulation
Le wording du warning catch laissait croire à un bug serveur alors que c'est le happy path "user inconnu".
- `"Error while setting UUID for user with specified username"` → `"user with specified username doesn't exist"`
- Suppression de la branche `else` morte (déjà couverte par le catch via `isset($uuid)==false`)

### `ListTroncs` / `ListQueteurs` — doc QR code
Ajout de commentaires expliquant que les rejets de validation sur les paramètres `q` (et `queteurIds` pour ListQueteurs) sont **attendus** : alimentés par des scans QR code décodés côté JS, les lecteurs peuvent produire des chaînes aberrantes. Les bornes (max int 1M pour ListTroncs, maxLength 100 pour ListQueteurs) servent de garde-fou.

### `docs/todo.md` — nouveau
TODO pour ajout de CHECK constraints SQL sur `queteur.nivol` et `users.nivol` (uppercase + trimmed) via migration Phinx, en remplacement défensif d'un patch PHP au niveau des writes. Contexte : 7 lignes `queteur` historiquement sales (import 2018) déjà nettoyées en SQL ; le code applicatif n'a pas produit de nouvelle donnée sale depuis. Une contrainte DB est plus chirurgicale qu'un `strtoupper(trim(ltrim()))` à chaque write.

## Impact prod attendu

| Métrique | Avant | Après |
|---|---|---|
| WARNING `SQL 0 rows` | ~536/28h | 0 (deviennent INFO) |
| WARNING faux "Error while setting UUID" | quelques/28h | 0 (wording corrigé, plus de stacktrace ambigu) |
| WARNING `Input value fails` sur `q` ListTroncs/ListQueteurs | ~30/28h | inchangé mais documenté comme attendu |

## Risque

🟢 **Quasi-nul.** Aucun changement de comportement applicatif, uniquement des niveaux de log et des commentaires. Le seul changement logique réel est la suppression du `else` mort dans `SendPasswordInitializationMailAction` — couvert par le `if(isset($uuid))` qui le précède.

## Tests

Pas de nouveau test (modifs purement cosmétiques côté log et commentaires). Le code applicatif n'est pas touché dans son comportement observable.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author