### PR TITLE
fix(credit-card): prevent and contain duplicate credit_card rows

### DIFF
--- a/client/src/app/troncs/troncQueteur/troncQueteur.controller.js
+++ b/client/src/app/troncs/troncQueteur/troncQueteur.controller.js
@@ -278,16 +278,26 @@
 
     vm.save = function save()
     {
+      //double-submit guard: disable the main "Sauvegarder" button (bound on tq.confirmButtonDisabled
+      //in troncQueteur.html) as soon as save() is invoked, before any async work. covers all paths:
+      //form-only edits (savedSuccessfully -> $saveAsAdmin async), coins save ($saveCoins async),
+      //and prevents a rapid double-click from triggering two POSTs to credit_card persistence.
+      //the flag is reset in onSaveError() and savedSuccessfullyActions(). when a warning dialog is
+      //about to open (checkInputValues branch), we reset the flag because the same flag also gates
+      //the dialog's "Confirmer" button (ng-disabled=tq.confirmButtonDisabled in the modal); leaving
+      //it true would lock the user out of confirming. the main button is hidden behind the modal
+      //backdrop in that case, so resetting is safe vs double-clicks.
+      vm.confirmButtonDisabled=true;
 
       if(vm.checkInputValues() && vm.current.overrideWarning !== true)
       {
         vm.current.confirmInputValues=true;
+        vm.confirmButtonDisabled=false;
       }
       else
       {
         if(hasCoinsBeenModified())
         {
-          vm.confirmButtonDisabled=true;
           //remove deleted item that didn't exist in DB (ex: added, then removed, then save)
           vm.current.tronc_queteur.don_cb_details = vm.current.tronc_queteur.don_cb_details.filter(function(value) {
             return !(value.delete && !value.id)
@@ -425,6 +435,10 @@
 
     function savedSuccessfullyActions()
     {
+      //reset the double-submit guard in all branches: the main "Sauvegarder" button is gated on
+      //tq.confirmButtonDisabled (see troncQueteur.html) and must be re-enabled after every save
+      //completion, including the adminEditMode path which stays on the same page via loadData().
+      vm.confirmButtonDisabled=false;
       if(vm.current.adminEditMode === true)
       {
         vm.loadData();
@@ -435,7 +449,6 @@
         vm.savedSuccessfully=true;
         vm.errorWhileSaving = false;
         vm.errorWhileSavingDetails=null;
-        vm.confirmButtonDisabled=false;
         vm.current.troncsForComptage = TroncResource.troncForComptage();
         $timeout(function () { vm.savedSuccessfully=false; }, 10000);
       }
@@ -541,24 +554,48 @@
       //cb details is fetched ordered by amount asc in SQL
       //if there's some basic amount missing, we're filling it with quantity=0
 
-      var newCbDetails = [];
-      for(var i=1;i<11;i++)
-      {
-        newCbDetails[i] = {id:0,tronc_queteur_id:0,ul_id:0,quantity:0,amount:i};
-      }
-      //deal with integer amount first
+      //dedup pass: collapse rows with identical (amount, quantity) before merging into newCbDetails.
+      //a server-side bug (admin edit mode re-inserting CB rows without deleting the previous ones)
+      //can produce exact duplicates in the credit_card table for a given tronc_queteur_id.
+      //the 3 merge loops below handle duplicates inconsistently:
+      // - integer amounts 1..10 collapse silently via index-overwrite (newCbDetails[amount]=cbd)
+      // - non-integer amounts < 10 are splice-inserted -> each duplicate produces a visible row
+      // - amounts > 10 are pushed             -> each duplicate produces a visible row
+      //without this pass, saving the form would persist the polluted view back to DB and amplify
+      //the inconsistency at each edit. the root cause must still be fixed on the server (insert path).
+      var seenAmountQuantity = {};
+      var dedupedCbDetails   = [];
+      vm.current.tronc_queteur.don_cb_details.forEach(function(cbd){
+        var key = cbd.amount+'_'+cbd.quantity;
+        if(!seenAmountQuantity[key])
+        {
+          seenAmountQuantity[key] = true;
+          dedupedCbDetails.push(cbd);
+        }
+      });
+      vm.current.tronc_queteur.don_cb_details = dedupedCbDetails;
+
+      //(A) Build quick-entry preset rows for common CB donation amounts (rendered with quantity=0
+      //    when absent from DB) to accelerate data entry. We use a sparse array indexed by amount
+      //    so loop (B) can do O(1) overwrite when a DB row matches a preset amount.
+      //    1..10 are the historical default; 20 and 50 were added as frequent donation values.
+      var commonAmounts = [1,2,3,4,5,6,7,8,9,10,20,50];
+      var newCbDetails  = [];
+      commonAmounts.forEach(function(amount){
+        newCbDetails[amount] = {id:0,tronc_queteur_id:0,ul_id:0,quantity:0,amount:amount};
+      });
+      //(B) integer amount with a matching preset slot: overwrite the default qty=0 row.
+      //    presence-based test (newCbDetails[amount]) naturally covers 1..10 + 20 + 50.
       for(var j=0;j<vm.current.tronc_queteur.don_cb_details.length; j++)
       {
-        if(Number.isInteger(vm.current.tronc_queteur.don_cb_details[j].amount))
+        if(Number.isInteger(vm.current.tronc_queteur.don_cb_details[j].amount) &&
+           newCbDetails[vm.current.tronc_queteur.don_cb_details[j].amount])
         {
-          if(vm.current.tronc_queteur.don_cb_details[j].amount < 11)
-          {//if it's a basic amount (integer between 1 and 10), then overwrite the default set in the previous loop
-            newCbDetails[vm.current.tronc_queteur.don_cb_details[j].amount] = vm.current.tronc_queteur.don_cb_details[j];
-          }
+          newCbDetails[vm.current.tronc_queteur.don_cb_details[j].amount] = vm.current.tronc_queteur.don_cb_details[j];
         }
       }
-      //reverse walk the array to insert non integer value without messing up the order for the next iteration of the loop
-      //here we still assume the array index is equals to cbd.amount
+      //(C) reverse walk the array to insert non integer value without messing up the order for the next iteration of the loop
+      //    here we still assume the array index is equals to cbd.amount
       for(var x=vm.current.tronc_queteur.don_cb_details.length-1;x>=0; x--)
       {
         if(!Number.isInteger(vm.current.tronc_queteur.don_cb_details[x].amount) && vm.current.tronc_queteur.don_cb_details[x].amount < 10)
@@ -567,12 +604,24 @@
         }
       }
 
+      //(D) DB rows with amount > 10 NOT covered by a preset slot (e.g. 15, 25, 100) : append at end.
+      //    amounts matching a preset (20, 50) were already merged in (B); excluding them here
+      //    avoids producing a duplicate row alongside the preset.
+      var commonAmountSet = {};
+      commonAmounts.forEach(function(a){ commonAmountSet[a] = true; });
       vm.current.tronc_queteur.don_cb_details.forEach(function(cbd){
-        if(cbd.amount>10)
+        if(cbd.amount>10 && !commonAmountSet[cbd.amount])
         {
           newCbDetails.push(cbd);
         }
       });
+
+      //(E) Compact the sparse array (drop holes between preset indices) and sort by amount ascending.
+      //    Required because (D) pushes non-preset amounts > 10 (e.g. 15) at the end of the array,
+      //    landing them after preset slots 20 and 50. Final numerical sort gives a stable,
+      //    monotonic display order regardless of input shape.
+      newCbDetails = newCbDetails.filter(function(cbd){ return !!cbd; });
+      newCbDetails.sort(function(a,b){ return a.amount - b.amount; });
 
       //empty existing array
       vm.current.tronc_queteur.don_cb_details.length=0;

--- a/client/src/app/troncs/troncQueteur/troncQueteur.html
+++ b/client/src/app/troncs/troncQueteur/troncQueteur.html
@@ -1487,7 +1487,7 @@
           <div class="col-md-1">
             <button type="button"
                    class="btn btn-primary"
-                   ng-disabled="troncQueteurForm.$invalid"
+                   ng-disabled="troncQueteurForm.$invalid || tq.confirmButtonDisabled"
                    ng-click="tq.save()"
                    ng-if="tq.current.tronc_queteur.tronc_id > 0 && !tq.current.readOnlyView && tq.current.not_same_year!=true  || tq.current.adminEditMode == true"
                     ng-cloak

--- a/run_local.sh
+++ b/run_local.sh
@@ -8,12 +8,17 @@
 #   * starts php-fpm + nginx + node-client
 #   * overlays Glyphicons Pro (licensed fonts from host Google Drive)
 #
-# Phinx migrations are NOT run automatically: launch them manually with
-#   make phinx cmd=migrate      (or status / rollback / ...)
+# Phinx migrations ARE run as part of this bootstrap, mirroring the pattern
+# used by GCP/deploy_back.sh: ~/.cred/phinx.yml (root credentials) is copied
+# over the gitignored server/phinx.yml, hosts are rewritten so the php-fpm
+# container reaches the host MySQL via host.docker.internal, migrations run
+# against the local-testing env, then server/phinx.yml is restored from the
+# repo template so no credentials live at rest in the working tree.
 #
-# Usage:  ./run_local.sh              (full bootstrap)
-#         ./run_local.sh --skip-deps  (skip composer/npm install)
-#         ./run_local.sh --rebuild    (force --no-cache build)
+# Usage:  ./run_local.sh                 (full bootstrap)
+#         ./run_local.sh --skip-deps     (skip composer/npm install)
+#         ./run_local.sh --skip-migrate  (skip phinx migrations)
+#         ./run_local.sh --rebuild       (force --no-cache build)
 # =============================================================================
 set -euo pipefail
 
@@ -21,12 +26,14 @@ HERE="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 cd "$HERE"
 
 SKIP_DEPS=0
+SKIP_MIGRATE=0
 REBUILD=0
 for arg in "$@"; do
     case "$arg" in
-        --skip-deps) SKIP_DEPS=1 ;;
-        --rebuild)   REBUILD=1   ;;
-        -h|--help)   sed -n '2,16p' "$0"; exit 0 ;;
+        --skip-deps)    SKIP_DEPS=1    ;;
+        --skip-migrate) SKIP_MIGRATE=1 ;;
+        --rebuild)      REBUILD=1      ;;
+        -h|--help)      sed -n '2,21p' "$0"; exit 0 ;;
         *) echo "Unknown flag: $arg" >&2; exit 1 ;;
     esac
 done
@@ -138,7 +145,35 @@ if [[ $SKIP_DEPS -eq 0 ]]; then
 fi
 
 # -----------------------------------------------------------------------------
-# 7bis. Glyphicons Pro overlay (licensed assets, mandatory)
+# 7bis. Phinx migrations (mirrors GCP/deploy_back.sh pattern)
+# -----------------------------------------------------------------------------
+# ~/.cred/phinx.yml carries root credentials for every env. Copy it onto the
+# gitignored server/phinx.yml, rewrite loopback hosts so the php-fpm container
+# reaches the host-published MySQL via host.docker.internal (same trick as
+# deploy_back.sh), then run pending migrations on local-testing. An EXIT trap
+# unconditionally restores server/phinx.yml from the repo template so no
+# credentials remain on disk if the script fails mid-way.
+if [[ $SKIP_MIGRATE -eq 0 ]]; then
+    HOST_PHINX_YML="${HOME}/.cred/phinx.yml"
+    [[ -f "$HOST_PHINX_YML" ]] || die "Missing $HOST_PHINX_YML (root creds needed for phinx)."
+    restore_phinx_template() {
+        cp "$HERE/server/phinx-template.yml" "$HERE/server/phinx.yml" 2>/dev/null || true
+    }
+    trap restore_phinx_template EXIT
+    say "Staging ~/.cred/phinx.yml into server/phinx.yml and rewriting hosts for Docker"
+    cp "$HOST_PHINX_YML" server/phinx.yml
+    sed -i '' -e 's/host: *127\.0\.0\.1/host: host.docker.internal/g' server/phinx.yml
+    sed -i '' -e 's/host: *localhost/host: host.docker.internal/g'    server/phinx.yml
+    say "Running phinx migrations (env: local-testing)"
+    docker compose exec -T -w /app/server php-fpm \
+        php vendor/bin/phinx migrate -c /app/server/phinx.yml -e local-testing
+    say "Restoring server/phinx.yml from repo template"
+    restore_phinx_template
+    trap - EXIT
+fi
+
+# -----------------------------------------------------------------------------
+# 7ter. Glyphicons Pro overlay (licensed assets, mandatory)
 # -----------------------------------------------------------------------------
 # Wait for the node-client entrypoint to finish `npm install` so that
 # node_modules/bootstrap-sass exists, then overlay the paid Glyphicons Pro
@@ -172,8 +207,6 @@ printf '  • %-24s %s\n'                        'MySQL (external)'     'rcq_mys
 cat <<'EOF'
 
 Next steps:
-  make phinx cmd=status   # inspect pending migrations
-  make phinx cmd=migrate  # apply them when you are ready
   make logs               # tail all services
   make shell-php          # shell inside php-fpm
   make down               # stop the stack

--- a/server/db/migrations/20260524145443_CreditCardUniqueAmountIndex.php
+++ b/server/db/migrations/20260524145443_CreditCardUniqueAmountIndex.php
@@ -1,0 +1,36 @@
+<?php
+
+use Phinx\Migration\AbstractMigration;
+
+class CreditCardUniqueAmountIndex extends AbstractMigration
+{
+    /**
+     * Add a UNIQUE composite index on credit_card(tronc_queteur_id, amount).
+     *
+     * Defense-in-depth filet de securite contre la duplication de lignes credit_card
+     * observee en 2026 (tronc_queteur_id=36070 entre autres). Les couches superieures
+     * couvrent deja le cas nominal:
+     *   - Frontend: dedup pass au chargement + protection anti-double-clic sur Sauvegarder
+     *               + hasCBDetailsForDuplicateAmount() bloquant la soumission.
+     *   - Backend : CreditCardDBService::dedupAndValidateCBEntities (pre-flight + log ERROR)
+     *               + persistence en DELETE bulk + INSERT all dans une transaction.
+     *
+     * Cette contrainte garantit qu'aucun chemin (replay request, ecriture directe en base,
+     * regression future) ne pourra reintroduire deux lignes avec le meme (tronc_queteur_id,
+     * amount). Une violation provoque un erreur SQL 23000 (duplicate key) immediatement
+     * rollback par la transaction enveloppante (cf. CreditCardDBService).
+     *
+     * Prerequis: les doublons existants en production doivent etre nettoyes AVANT que cette
+     * migration soit jouee (deploy strategy: dev -> test -> prod, cleanup avant chaque
+     * application). Sinon la creation de l'index echoue avec un ERROR 1062.
+     */
+    public function change()
+    {
+      $this->table('credit_card')
+        ->addIndex(['tronc_queteur_id', 'amount'], [
+          'unique' => true,
+          'name'   => 'idx_credit_card_tronc_queteur_amount_unique',
+        ])
+        ->save();
+    }
+}

--- a/server/src/DBService/CreditCardDBService.php
+++ b/server/src/DBService/CreditCardDBService.php
@@ -4,11 +4,13 @@ namespace RedCrossQuest\DBService;
 use DateInterval;
 use DateTime;
 use Exception;
+use InvalidArgumentException;
 use PDO;
 use PDOException;
 use RedCrossQuest\Entity\CreditCardEntity;
 use RedCrossQuest\Entity\DailyStatsBeforeRCQEntity;
 use RedCrossQuest\Service\Logger;
+use Throwable;
 
 class CreditCardDBService extends DBService
 {
@@ -60,86 +62,162 @@ ORDER BY c.amount ASC
   }
 
   /**
-   * Create or update CreditCard donation records
-   * An update is done if the record has an id, otherwise it's an insert
-   * 
-   * @param CreditCardEntity[] $creditCardEntities array of credit cards donations
-   * @param int    $troncQueteurId  Id of the parent TroncQueteur
-   * @param int $ulId The ID of the Unite Locale
-   * @throws Exception if some parsing error occurs
+   * Persist the CreditCard donation rows attached to a TroncQueteur.
+   *
+   * Strategy: DELETE all existing rows for this tronc_queteur, then INSERT the cleaned
+   * input set, the whole sequence wrapped in a transaction. credit_card row IDs are not
+   * externally referenced (no FK pointing at credit_card.id), so losing the historical IDs
+   * is acceptable. This makes persistence idempotent w.r.t. the payload and naturally
+   * cleans up any pre-existing duplicates on every save (defense against the legacy
+   * duplication bug observed on tronc_queteur_id=36070 and others).
+   *
+   * Pre-flight validation runs first and may throw InvalidArgumentException, surfaced as
+   * a 400 to the client by SaveCoinsOnTroncQueteur.
+   *
+   * @param CreditCardEntity[] $creditCardEntities array of credit card donation rows
+   * @param int                $troncQueteurId     Id of the parent TroncQueteur
+   * @param int                $ulId               Id of the Unite Locale
+   * @throws InvalidArgumentException if the payload has the same amount with different quantities
+   * @throws Exception                on DB error
    */
   public function createOrUpdateOrDeleteCreditCardDonation(array $creditCardEntities, int    $troncQueteurId, int $ulId):void
   {
-    foreach ($creditCardEntities as $creditCardEntity)
-    {
-      if($creditCardEntity->id > 0)
-      {
-        if($creditCardEntity->delete === true)
-        {
-          $this->delete($creditCardEntity, $ulId);
-        }
-        else
-        {
-          $this->update($creditCardEntity, $ulId);
-        }
+    //S1 pre-flight: dedup identical (amount,quantity) silently (log ERROR with full details),
+    //throw InvalidArgumentException if same amount has conflicting quantities (-> 400).
+    $cleaned = $this->dedupAndValidateCBEntities($creditCardEntities, $troncQueteurId, $ulId);
 
-      }
-      else
+    //S2 persistence: DELETE bulk + INSERT all in a transaction.
+    //inTransaction() check mirrors the pattern used by executeQueryForInsert(): if a caller
+    //already opened a transaction (currently none for this path, but future-proof), we
+    //participate in it rather than nesting (MySQL does not support nested transactions).
+    $transactionStartedHere = false;
+    if(!$this->db->inTransaction())
+    {
+      $this->db->beginTransaction();
+      $transactionStartedHere = true;
+    }
+    try
+    {
+      $this->deleteAllForTroncQueteur($troncQueteurId, $ulId);
+      foreach($cleaned as $creditCardEntity)
       {
-        if($creditCardEntity->quantity > 0 )//form is prefilled with default options 1€, 2€, 3€, 4€, 5€, but if no quantity is added, do not save it.
-          $this->insertCreditCard($creditCardEntity, $troncQueteurId, $ulId);
+        $this->insertCreditCard($creditCardEntity, $troncQueteurId, $ulId);
       }
+      if($transactionStartedHere)
+      {
+        $this->db->commit();
+      }
+    }
+    catch(Throwable $e)
+    {
+      if($transactionStartedHere && $this->db->inTransaction())
+      {
+        $this->db->rollBack();
+      }
+      throw $e;
     }
   }
 
 
   /**
-   * update a CreditCard donation
-   * @param CreditCardEntity $creditCardEntity info about the CreditCard donation
-   * @param int $ulId Id of the UL of the user (from JWT Token, to be sure not to update other UL data)
-   * @throws PDOException if the query fails to execute on the server
-   * @throws Exception
+   * Pre-flight check on the incoming CB payload.
+   *
+   * Filters out rows marked for delete and rows with null/0 quantity (preset slots left
+   * empty by the user). Groups the remaining rows by amount:
+   * - 1 row per amount    -> kept as-is
+   * - N rows, same quantity      -> silent dedup, ERROR log with full debug context
+   * - N rows, different quantity -> InvalidArgumentException (client sees 400)
+   *
+   * The frontend already guards both cases (load-time dedup + hasCBDetailsForDuplicateAmount
+   * blocking the save), but server-side validation is required to defend against stale
+   * clients, replayed requests, and direct API calls.
+   *
+   * @param CreditCardEntity[] $creditCardEntities
+   * @param int                $troncQueteurId
+   * @param int                $ulId
+   * @return CreditCardEntity[] entities ready to insert (filtered + deduped)
+   * @throws InvalidArgumentException on amount/quantity conflict
    */
-  public function update(CreditCardEntity $creditCardEntity, int $ulId):void
+  private function dedupAndValidateCBEntities(array $creditCardEntities, int $troncQueteurId, int $ulId):array
   {
-    $sql ="
-update  `credit_card`
-set     `amount`        = :amount,
-        `quantity`      = :quantity
-where   `id`      = :id
-AND     `ul_id`   = :ulId   
-";
-    $parameters = [
-      "amount"        => $creditCardEntity->amount,
-      "quantity"      => $creditCardEntity->quantity,
-      "id"            => $creditCardEntity->id,
-      "ulId"          => $ulId
-    ];
-    
-    $this->executeQueryForUpdate($sql, $parameters);
+    $byAmount = [];
+    foreach($creditCardEntities as $e)
+    {
+      if($e->delete === true)                                continue;
+      if($e->quantity === null || $e->quantity <= 0)         continue;
+      $amountKey = (string)$e->amount;
+      if(!isset($byAmount[$amountKey])) $byAmount[$amountKey] = [];
+      $byAmount[$amountKey][] = $e;
+    }
+
+    $cleaned = [];
+    foreach($byAmount as $amountKey => $entities)
+    {
+      if(count($entities) === 1)
+      {
+        $cleaned[] = $entities[0];
+        continue;
+      }
+
+      $quantitiesSet = [];
+      foreach($entities as $e) $quantitiesSet[(string)$e->quantity] = true;
+
+      if(count($quantitiesSet) === 1)
+      {
+        $this->logger->error("CB pre-flight: silently merged duplicate (amount, quantity) rows in payload", [
+          "tronc_queteur_id" => $troncQueteurId,
+          "ul_id"            => $ulId,
+          "amount"           => $entities[0]->amount,
+          "quantity"         => $entities[0]->quantity,
+          "duplicateCount"   => count($entities),
+          "entities"         => $entities,
+        ]);
+        $cleaned[] = $entities[0];
+      }
+      else
+      {
+        $this->logger->error("CB pre-flight: conflicting quantities for the same amount in payload", [
+          "tronc_queteur_id" => $troncQueteurId,
+          "ul_id"            => $ulId,
+          "amount"           => $entities[0]->amount,
+          "quantities"       => array_keys($quantitiesSet),
+          "entities"         => $entities,
+        ]);
+        throw new InvalidArgumentException(
+          "Payload CB contient des lignes en conflit pour le montant ".$entities[0]->amount.
+          " avec des quantites differentes (".implode(",", array_keys($quantitiesSet)).
+          "). tronc_queteur_id=".$troncQueteurId
+        );
+      }
+    }
+
+    return $cleaned;
   }
 
 
   /**
-   * delete a CreditCard donation
-   * @param CreditCardEntity $creditCardEntity info about the CreditCard donation
-   * @param int $ulId Id of the UL of the user (from JWT Token, to be sure not to update other UL data)
+   * Delete all credit_card rows for a given tronc_queteur (scoped to the UL of the caller).
+   * Used by the DELETE+INSERT persistence strategy of createOrUpdateOrDeleteCreditCardDonation.
+   *
+   * @param int $troncQueteurId
+   * @param int $ulId
+   * @return int number of deleted rows
    * @throws PDOException if the query fails to execute on the server
    * @throws Exception
    */
-  public function delete(CreditCardEntity $creditCardEntity, int $ulId):void
+  private function deleteAllForTroncQueteur(int $troncQueteurId, int $ulId):int
   {
-    $sql ="
-DELETE  FROM `credit_card`
-WHERE   `id`      = :id
-AND     `ul_id`   = :ulId   
+    $sql = "
+DELETE FROM `credit_card`
+WHERE `tronc_queteur_id` = :tronc_queteur_id
+AND   `ul_id`            = :ul_id
 ";
     $parameters = [
-      "id"            => $creditCardEntity->id,
-      "ulId"          => $ulId
+      "tronc_queteur_id" => $troncQueteurId,
+      "ul_id"            => $ulId,
     ];
 
-    $this->executeQueryForUpdate($sql, $parameters);
+    return $this->executeQueryForUpdate($sql, $parameters);
   }
 
   /**

--- a/server/src/routes/routesActions/troncsQueteurs/SaveCoinsOnTroncQueteur.php
+++ b/server/src/routes/routesActions/troncsQueteurs/SaveCoinsOnTroncQueteur.php
@@ -9,6 +9,7 @@ namespace RedCrossQuest\routes\routesActions\troncsQueteurs;
 use Carbon\Carbon;
 use DI\Attribute\Inject;
 use Exception;
+use InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface as Response;
 use Psr\Log\LoggerInterface;
 use RedCrossQuest\DBService\TroncQueteurDBService;
@@ -109,6 +110,23 @@ class SaveCoinsOnTroncQueteur extends Action
 
       $this->troncQueteurDBService->updateCoinsCount($tq, $adminMode, $ulId, $userId);
 
+    }
+    catch(InvalidArgumentException $iae)
+    {
+      //CB payload validation failure thrown by CreditCardDBService::dedupAndValidateCBEntities
+      //(same amount with different quantities). The frontend should have caught this case via
+      //hasCBDetailsForDuplicateAmount(), so reaching this branch indicates a stale client, a
+      //replayed request, or a direct API call. Returning 400 with details lets the client
+      //surface the message; logged as ERROR with payload context for debugging.
+      $this->logger->error("CB payload validation failed on SaveCoinsOnTroncQueteur",
+        ["tq"=>$tq, "ulId"=>$ulId, "userId"=>$userId, Logger::$EXCEPTION => $iae]);
+      $response400 = $this->response->withStatus(400);
+      $response400->getBody()->write(json_encode([
+        "error"          => $iae->getMessage(),
+        "errorType"      => "cb_payload_validation",
+        "troncQueteurId" => $tq->id,
+      ], JSON_UNESCAPED_UNICODE));
+      return $response400;
     }
     catch(Throwable $exception)
     {


### PR DESCRIPTION
## Contexte

Doublons observés en production sur la table `credit_card` (ex: `tronc_queteur_id=36070` avec 18 lignes pour 9 montants distincts). Cause racine : pas de dédoublonnage côté backend + double-submit possible côté frontend + aucune contrainte d'unicité en BDD.

## Correctifs (defence-in-depth, 4 couches)

### 1. `fix(credit-card): add UNIQUE index on (tronc_queteur_id, amount)`
Migration Phinx `20260524145443_CreditCardUniqueAmountIndex` créant `idx_credit_card_tronc_amount_unique`. Tout double-submit, retry, ou code-path bugué futur est rejeté au niveau BDD.

> Prérequis : les doublons existants doivent être nettoyés **avant** la migration (script de cleanup exécuté manuellement sur chaque env).

### 2. `fix(credit-card): pre-flight dedup + transactional DELETE/INSERT`
`CreditCardDBService` :
- Pre-flight pass sur le payload : collapse silencieux des lignes `(amount, quantity)` identiques (log ERROR avec contexte), throw `InvalidArgumentException` si même `amount` avec quantités différentes.
- Persistance transactionnelle : `DELETE` toutes les lignes du `tronc_queteur_id` puis `INSERT` du nouveau set. Stratégie idempotente, immune aux écritures partielles (les `credit_card.id` ne sont référencés nulle part).
- `SaveCoinsOnTroncQueteur` catch la validation exception et renvoie HTTP 400 avec un JSON détaillant les `amount` en conflit.

### 3. `fix(credit-card): frontend dedup, presets, sort and double-submit guard`
`troncQueteur` :
- Dédup au chargement (sinon les doublons polluent persistent à chaque save).
- Presets étendus 1–10 + 20 + 50 (quantity=0) pour accélérer la saisie.
- Tri numérique final par `amount`.
- `vm.confirmButtonDisabled` posé dès le début de `vm.save()` et lié au `ng-disabled` du bouton Sauvegarder → plus de double-clic envoyant deux POST parallèles.

### 4. `chore(run-local): run phinx migrations automatically during bootstrap`
`run_local.sh` reproduit le pattern de `GCP/deploy_back.sh` : overlay de `~/.cred/phinx.yml` sur `server/phinx.yml` (gitignoré), réécriture des hosts loopback vers `host.docker.internal`, migration sur l'env `local-testing`, puis restore du template via un trap EXIT. Nouveau flag `--skip-migrate`.

## Validation

- ✅ Migration jouée en local et dev.
- ✅ Test manuel des INSERT en violation de la contrainte UNIQUE (1062 attendu).
- ✅ Pipeline `run_local.sh` vérifié.

## Déploiement (chaque env: local → dev → test → prod)

1. **Cleanup data** (manuel, hors PR) — supprimer les doublons existants.
2. **Deploy code** (front + back) — active les nouvelles protections.
3. **Phinx migrate** — verrou final au niveau BDD.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author