### PR TITLE
feat(coin-order): UL-wide coin display order setting (replaces per-browser localStorage)

### DIFF
--- a/client/src/app/admin/Settings/settings.html
+++ b/client/src/app/admin/Settings/settings.html
@@ -535,6 +535,41 @@
             </div>
           </div>
         </div>
+        <div class="row" style="padding-top:15px">
+          <div class="col-md-4">
+            <div class="form-group" ng-class="{'has-error':ulRedCrossQuestSettingsForm.CoinOrder.$invalid}">
+              <label for="CoinOrderRadio1" class="control-label">Ordre des pièces (machine à compter)</label> <br/>
+              <label class="radio-inline">
+                <input type="radio" name="CoinOrder" id="CoinOrderRadio1" ng-model="s.applicationSettings.coin_order" ng-value="1" ng-required> Par taille
+              </label>
+              <label class="radio-inline">
+                <input type="radio" name="CoinOrder" id="CoinOrderRadio2" ng-model="s.applicationSettings.coin_order" ng-value="2" ng-required> Par valeur
+              </label>
+              <span class="help-block">
+                Choisissez l'ordre d'affichage des pièces sur le formulaire de comptage en fonction de l'ordre des bacs de votre machine à compter les pièces. Ce paramètre est commun à toute l'UL pour éviter les erreurs de saisie entre différents utilisateurs.
+              </span>
+            </div>
+          </div>
+          <div class="col-md-8">
+            <div class="panel panel-info">
+              <div class="panel-heading">Aperçu de l'ordre d'affichage</div>
+              <div class="panel-body">
+                <div ng-if="s.applicationSettings.coin_order == 1 || !s.applicationSettings.coin_order">
+                  <strong>Par taille :</strong>
+                  <span style="font-family: monospace; font-size: 14px;">
+                    2&nbsp;€ &rarr; 50&nbsp;c &rarr; 1&nbsp;€ &rarr; 20&nbsp;c &rarr; 5&nbsp;c &rarr; 10&nbsp;c &rarr; 2&nbsp;c &rarr; 1&nbsp;c
+                  </span>
+                </div>
+                <div ng-if="s.applicationSettings.coin_order == 2">
+                  <strong>Par valeur :</strong>
+                  <span style="font-family: monospace; font-size: 14px;">
+                    2&nbsp;€ &rarr; 1&nbsp;€ &rarr; 50&nbsp;c &rarr; 20&nbsp;c &rarr; 10&nbsp;c &rarr; 5&nbsp;c &rarr; 2&nbsp;c &rarr; 1&nbsp;c
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
         <div class="row" style="padding-top:25px">
           <div class="col-md-2 col-md-offset-10">
             <button type="button" class="btn btn-primary" ng-disabled="ulApplicationSettingsForm.$invalid" ng-show="s.currentUserRole>=4" ng-click='s.updateRedCrossQuestSettings();'>Sauvegarder</button>

--- a/client/src/app/main/main.html
+++ b/client/src/app/main/main.html
@@ -1,5 +1,17 @@
 <acme-navbar></acme-navbar>
 <div class="container">
+  <!-- Permanent announcement banner: coin order is now a UL-wide setting (Firestore).
+       To be removed next year. -->
+  <div class="row" style="margin-bottom: 10px;">
+    <div class="col-md-10 col-md-offset-1">
+      <uib-alert type="info">
+        <strong>Nouveau cette année :</strong> Le réglage <strong>Ordre des pièces</strong>
+        a été déplacé dans <strong>Administration &rarr; Paramétrage de l'UL &rarr; Paramètre RedCrossQuest</strong>.
+        Ce paramètre est désormais global pour l'UL afin d'éviter les erreurs de saisie entre différents utilisateurs.
+      </uib-alert>
+    </div>
+  </div>
+
   <div class="row hidden-sm hidden-xs" ng-show="main.currentUserRole >= 4">
     <div class="panel panel-default">
       <!-- Default panel contents -->
@@ -71,6 +83,7 @@
                 <li>Il y a 3 parties : Coordonnées de l'unité locales, Paramétrage de RedCrossQuest et Paramétrage de RedQuest</li>
                 <li>Coordonnées: email, téléphone, adresse postale (utilisé comme référence pour définir les trajets base à point de quête), les coordonnées des administrateurs, trésorier et président de l'unité locale.</li>
                 <li>RedCrossQuest : vous pouvez activer la fonction 'Sac de Banque', qui vous permet de définir dans quel sac vous versez le contenu d'un tronc. </li>
+                <li><b>Nouveau</b> : <b>Ordre des pièces</b> : en fonction de l'ordre d'affichage des pièces de votre machine à compter les pièces, choississez l'ordre des pièces par taille ou par valeur. Ce paramètre est désormais global à l'UL (auparavant il était propre à chaque navigateur).</li>
                 <li>RedQuest : Affichage dans l'application mobile pour le quêteur du classement des quêteurs (toutes les pages, premières pages, aucune), des stats journalières (en construction), laissez le quêteur définir son heure de départ et retour.</li>
               </ol>
             </li>

--- a/client/src/app/troncs/troncQueteur/troncQueteur.controller.js
+++ b/client/src/app/troncs/troncQueteur/troncQueteur.controller.js
@@ -22,16 +22,12 @@
     vm.onlyNumbers    = /^[0-9]{1,3}$/;
     vm.cbFormat       = /^[0-9]+(\.[0-9]{1,2})?$/;
 
-    vm.coins_order    = $localStorage.guiSettings.coins_order;
-    if(!vm.coins_order)
-    {//coins ordered by size by default
-      vm.coins_order = 1;
-    }
-
-    vm.setCoinsOrderInLocalCache=function(coins_order)
-    {
-      $localStorage.guiSettings.coins_order = coins_order;
-    };
+    //coin display order is now a UL-wide preference managed by admins from the
+    //settings page (Administration -> Paramétrage de l'UL -> Paramètre RCQ).
+    //The legacy per-browser $localStorage.guiSettings.coins_order has been removed:
+    //it caused inconsistent entries when multiple users counted on the same machine.
+    //Default to 1 (Par taille) if the UL has not been migrated yet.
+    vm.coins_order = ($localStorage.guiSettings.ul_settings && $localStorage.guiSettings.ul_settings.coin_order) || 1;
 
     vm.currentUserRole= $localStorage.currentUser.roleId;
     vm.currentUlMode  = $localStorage.currentUser.ulMode;

--- a/client/src/app/troncs/troncQueteur/troncQueteur.html
+++ b/client/src/app/troncs/troncQueteur/troncQueteur.html
@@ -714,15 +714,18 @@
                 <div class="col-md-2">
                   <strong>PIÈCES</strong>
                 </div>
-                <div class="col-md-4 col-md-offset-6"style="font-size:small">
-                  <div class="form-group">
-                    <label for="coins_order1" class="control-label">Ordre des pièces &nbsp;&nbsp;&nbsp;</label>
-                    <label class="radio-inline">
-                      <input type="radio" name="active" id="coins_order1" ng-model="tq.coins_order" ng-value="1" required ng-click="tq.setCoinsOrderInLocalCache(1)"> Par taille
-                    </label>
-                    <label class="radio-inline">
-                      <input type="radio" name="active" id="coins_order2" ng-model="tq.coins_order" ng-value="2" required ng-click="tq.setCoinsOrderInLocalCache(2)"> Par valeur
-                    </label>
+                <div class="col-md-8 col-md-offset-2" style="font-size:small">
+                  <!-- Coin order is now a UL-wide setting managed by admins.
+                       See client/src/app/admin/Settings/settings.html -->
+                  <div class="alert alert-danger" role="alert" style="border: 2px solid #a94442; margin-bottom: 0;">
+                    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+                    <strong>Ordre des pièces :</strong>
+                    <span ng-if="tq.coins_order == 1">par taille</span>
+                    <span ng-if="tq.coins_order == 2">par valeur</span>.
+                    Ce paramètre est désormais global pour toute l'UL.
+                    Pour le modifier, rendez-vous dans
+                    <strong>Administration &rarr; Paramétrage de l'UL &rarr; Paramètre RedCrossQuest</strong>
+                    (accessible aux profils Compteur, Admin et Superadmin).
                   </div>
                 </div>
               </div>

--- a/server/src/Entity/ULPreferencesEntity.php
+++ b/server/src/Entity/ULPreferencesEntity.php
@@ -29,6 +29,11 @@ final class ULPreferencesEntity extends Entity
   /** @var ?bool $rq_autonomous_depart_and_return Can volunteers set the depart & return date themselves with RedQuest*/
   public ?bool $rq_autonomous_depart_and_return;
 
+  /** @var ?int $coin_order Display order of coins on the tronc_queteur counting form.
+   * 1 = by size (default), 2 = by value. UL-wide setting, replaces the legacy
+   * per-browser $localStorage.guiSettings.coins_order. */
+  public ?int $coin_order;
+
 
   /** @var ?string $token_benevole  token used for registration from RedQuest. Fetch from MySQL, not Firestore*/
   public ?string $token_benevole    = null                ;
@@ -39,8 +44,11 @@ final class ULPreferencesEntity extends Entity
   public static string $RQ_DISPLAY_QUETE_STATS_NONE      = "NONE"    ;
   public static string $RQ_DISPLAY_QUETE_STATS_1ST_PAGE  = "1ST_PAGE";
   public static string $RQ_DISPLAY_QUETE_STATS_ALL       = "ALL"     ;
-  
-  protected array $_fieldList = ['ul_id', 'rq_display_daily_stats', 'rq_display_queteur_ranking', 'use_bank_bag', 'check_dates_not_in_the_past', 'rq_autonomous_depart_and_return', 'token_benevole', 'token_benevole_1j'];
+
+  public static int    $COIN_ORDER_BY_SIZE               = 1         ;
+  public static int    $COIN_ORDER_BY_VALUE              = 2         ;
+
+  protected array $_fieldList = ['ul_id', 'rq_display_daily_stats', 'rq_display_queteur_ranking', 'use_bank_bag', 'check_dates_not_in_the_past', 'rq_autonomous_depart_and_return', 'coin_order', 'token_benevole', 'token_benevole_1j'];
 
   /**
    * Accept an array of data matching properties of this class
@@ -59,6 +67,7 @@ final class ULPreferencesEntity extends Entity
     $this->getBoolean('rq_display_daily_stats'         , $data);
     $this->getBoolean('rq_autonomous_depart_and_return', $data);
     $this->getString ('rq_display_queteur_ranking'     , $data, 8);
+    $this->getInteger('coin_order'                     , $data);
   }
 
   /**

--- a/server/src/routes/routesActions/settings/GetAllULSettings.php
+++ b/server/src/routes/routesActions/settings/GetAllULSettings.php
@@ -124,6 +124,7 @@ class GetAllULSettings extends Action
       $data['rq_autonomous_depart_and_return'] = false;
       $data['rq_display_daily_stats'         ] = true;
       $data['rq_display_queteur_ranking'     ] = ULPreferencesEntity::$RQ_DISPLAY_QUETE_STATS_ALL;
+      $data['coin_order'                     ] = ULPreferencesEntity::$COIN_ORDER_BY_SIZE;
       $data['ul_id'                          ] = $ulId;
 
       $ulPreferenceEntity = ULPreferencesEntity::withArray($data, $this->logger);

--- a/server/src/routes/routesActions/settings/UpdateRedCrossQuestSettings.php
+++ b/server/src/routes/routesActions/settings/UpdateRedCrossQuestSettings.php
@@ -50,8 +50,17 @@ class UpdateRedCrossQuestSettings extends Action
       [
         ClientInputValidatorSpecs::withBoolean("use_bank_bag"                , $this->parsedBody, true, false),
         ClientInputValidatorSpecs::withBoolean("check_dates_not_in_the_past" , $this->parsedBody, true, true ),
+        ClientInputValidatorSpecs::withInteger("coin_order"                  , $this->parsedBody, 2  , false, ULPreferencesEntity::$COIN_ORDER_BY_SIZE),
       ]);
 
+    //coin_order is a UL-wide preference (1 = by size [default], 2 = by value),
+    //replacing the legacy per-browser $localStorage.guiSettings.coins_order on
+    //the tronc_queteur counting form. Normalize anything outside {1,2} to the default.
+    $coinOrder = $this->validatedData["coin_order"];
+    if($coinOrder !== ULPreferencesEntity::$COIN_ORDER_BY_SIZE && $coinOrder !== ULPreferencesEntity::$COIN_ORDER_BY_VALUE)
+    {
+      $coinOrder = ULPreferencesEntity::$COIN_ORDER_BY_SIZE;
+    }
 
     $ulId   = $this->decodedToken->getUlId();
 
@@ -64,6 +73,7 @@ class UpdateRedCrossQuestSettings extends Action
 
       $data['use_bank_bag'               ] = $this->validatedData["use_bank_bag"];
       $data['check_dates_not_in_the_past'] = $this->validatedData["check_dates_not_in_the_past"];
+      $data['coin_order'                 ] = $coinOrder;
 
       $data['ul_id'       ] = $ulId;
 
@@ -73,6 +83,7 @@ class UpdateRedCrossQuestSettings extends Action
     {
       $ulPreferenceEntity->use_bank_bag                = $this->validatedData["use_bank_bag"               ];
       $ulPreferenceEntity->check_dates_not_in_the_past = $this->validatedData["check_dates_not_in_the_past"];
+      $ulPreferenceEntity->coin_order                  = $coinOrder;
     }
 
     $this->ULPreferencesFirestoreDBService ->updateUlPrefs($ulId, $ulPreferenceEntity);


### PR DESCRIPTION
## Contexte

Le réglage **Ordre des pièces** sur le formulaire de comptage `tronc_queteur` était jusqu'ici stocké dans `$localStorage.guiSettings.coins_order` (par navigateur). Plusieurs utilisateurs comptant sur le même poste pouvaient ainsi se retrouver avec des ordres incohérents → erreurs de saisie.

Le réglage devient **global à l'UL** et stocké dans **Firestore** (`ULPreferencesEntity`, comme `use_bank_bag`, `check_dates_not_in_the_past`, etc.).

## Changements

### Backend (PHP / Slim 4 / Firestore)
- `ULPreferencesEntity` : nouveau champ `?int $coin_order` + constantes `$COIN_ORDER_BY_SIZE = 1` (défaut) / `$COIN_ORDER_BY_VALUE = 2`, ajout dans `_fieldList` et parsing constructeur
- `UpdateRedCrossQuestSettings` : validation `coin_order` (int, defaultValue=1), normalisation des valeurs hors `{1,2}`, persistance Firestore (route déjà restreinte à `role-id:[4-9]`)
- `GetAllULSettings` : défaut `coin_order = 1` lors de l'initialisation d'une nouvelle UL

### Frontend Admin (`settings.html`)
- Nouvelle ligne dans la section **Paramètre RedCrossQuest** : radio *Par taille* / *Par valeur* + panneau d'aperçu texte montrant l'ordre résultant (ex. `2 € → 50 c → 1 € → ...`)

### Frontend Tronc Quêteur
- `troncQueteur.controller.js` : lecture depuis `$localStorage.guiSettings.ul_settings.coin_order` (fallback `|| 1`)
- `troncQueteur.html` : ancien sélecteur radio remplacé par un encart rouge bordé indiquant la valeur courante et renvoyant vers *Administration → Paramétrage de l'UL → Paramètre RedCrossQuest*
- Suppression complète de `vm.setCoinsOrderInLocalCache` et de toute écriture vers `$localStorage.guiSettings.coins_order`

### Frontend Accueil (`main.html`)
- `uib-alert` permanente (non-dismissable, à retirer l'année prochaine) annonçant le déplacement du paramètre
- Nouvelle ligne *Nouveau : Ordre des pièces* dans le premier fieldset **Paramètres de l'Unité Locale** du panneau *Afficher les instructions de paramétrage RCQ*

## Pas de migration de base

Stockage = Firestore → aucune migration Phinx requise.

Pour les UL existantes : au prochain login, `coin_order` sera `undefined` côté client → fallback `|| 1` (par taille). L'admin devra aller dans `/settings` pour figer la valeur (ou la modifier). Communication prévue : message groupe interne + email aux admins connectés cette année.

## Tests effectués

Déploiement de test (`make deploy-all ENV=test`) déjà réalisé.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author