### PR TITLE
feat(troncs): Point de quête column on depart/retour/comptage + comptage fixes

### DIFF
--- a/GCP/deploy_back.sh
+++ b/GCP/deploy_back.sh
@@ -120,6 +120,7 @@ docker compose run --rm --no-deps \
         set -e
         [[ -d vendor ]] || composer install --no-interaction --no-progress
         composer check:routes
+        bash regenerate-php-di-cache.sh
         php vendor/bin/phinx migrate -c /app/server/phinx.yml -e rcq-'"${COUNTRY}"'-'"${ENV}"'
     '
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ NODE_EXEC:= $(DC) exec -T node-client
         phinx-migrate phinx-rollback phinx \
         gulp-serve gulp-build \
         shell-php shell-node \
+        refresh-di \
         clean nuke doctor
 
 help: ## Show available targets
@@ -57,6 +58,9 @@ composer-update: ## composer update
 
 composer: ## Arbitrary composer cmd: `make composer cmd="require foo/bar"`
 	$(PHP_EXEC) composer $(cmd)
+
+refresh-di: ## Purge compiled PHP-DI container + regenerate optimized autoloader
+	$(DC) exec -T -w /app/server php-fpm bash regenerate-php-di-cache.sh
 
 npm: ## npm in the node-client container: `make npm cmd="install"`
 	$(NODE_EXEC) npm $(cmd)

--- a/client/src/app/troncs/depart/departTronc.html
+++ b/client/src/app/troncs/depart/departTronc.html
@@ -48,39 +48,6 @@
             </div>
 
 
-            <div class="row visible-lg-block" ng-show="!(dt.current.tronc_queteur.id>0)" ng-cloak>
-              <div class="col-md-12">
-                <span class="label label-primary">Liste des troncs prêts au départ</span>
-
-                <table class="table table-hover table-condensed histo">
-                  <thead>
-                  <tr>
-                    <th>Sélect            </th>
-                    <th>Tronc             </th>
-                    <th>Prénom            </th>
-                    <th>Nom               </th>
-                    <th>Point de quête    </th>
-                    <th>Départ Théo       </th>
-                    <th>TroncQueteur      </th>
-                  </tr>
-                  </thead>
-
-                  <tbody>
-                  <tr ng-repeat="t in dt.current.troncsForDepart.rows" ng-class-odd="'oddRows'" ng-class-even="'evenRows'">
-                    <td><button type="button" ng-model="singleModel" class="btn btn-primary" uib-btn-checkbox ng-click="dt.troncDecodedAndFoundInDB(t)"><span class="glyphicon glyphicon-floppy-disk"  aria-hidden="true"></span></button></td>
-                    <td style="text-align: center">{{::t.id }}</td>
-                    <td>{{::t.first_name  }}</td>
-                    <td>{{::t.last_name   }}</td>
-                    <td>{{::t.point_quete_name}}</td>
-                    <td>{{::t.depart_theorique | date:'dd/MM/yyyy HH:mm'}}</td>
-                    <td style="text-align: center"><a ng-href="/#!/tronc_queteur/edit/{{::t.tronc_queteur_id}}" target='_blank'>{{::t.tronc_queteur_id}}</a></td>
-                  </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-
-
             <div class="form-group" ng-show="dt.current.tronc_queteur.id>0">
               <label for="lieuDeQuete" class="control-label">Lieu de Quête</label>
               <select name="lieuDeQuete" id="lieuDeQuete" class="form-control" ng-model="dt.current.tronc_queteur.point_quete.id" disabled
@@ -114,6 +81,38 @@
                      readonly/>
               <span class="help-block" ng-show="departTroncForm.depart.$error.required">Required</span>
             </div>
+          </div>
+        </div>
+
+        <div class="row visible-lg-block" ng-show="!(dt.current.tronc_queteur.id>0)" ng-cloak>
+          <div class="col-md-12">
+            <span class="label label-primary">Liste des troncs prêts au départ</span>
+
+            <table class="table table-hover table-condensed histo">
+              <thead>
+              <tr>
+                <th>Sélect            </th>
+                <th>Tronc             </th>
+                <th>Prénom            </th>
+                <th>Nom               </th>
+                <th>Point de quête    </th>
+                <th>Départ Théorique  </th>
+                <th>TroncQueteur      </th>
+              </tr>
+              </thead>
+
+              <tbody>
+              <tr ng-repeat="t in dt.current.troncsForDepart.rows" ng-class-odd="'oddRows'" ng-class-even="'evenRows'">
+                <td><button type="button" ng-model="singleModel" class="btn btn-primary" uib-btn-checkbox ng-click="dt.troncDecodedAndFoundInDB(t)"><span class="glyphicon glyphicon-floppy-disk"  aria-hidden="true"></span></button></td>
+                <td style="text-align: center">{{::t.id }}</td>
+                <td>{{::t.first_name  }}</td>
+                <td>{{::t.last_name   }}</td>
+                <td>{{::t.point_quete_name}}</td>
+                <td>{{::t.depart_theorique | date:'dd/MM/yyyy HH:mm'}}</td>
+                <td style="text-align: center"><a ng-href="/#!/tronc_queteur/edit/{{::t.tronc_queteur_id}}" target='_blank'>{{::t.tronc_queteur_id}}</a></td>
+              </tr>
+              </tbody>
+            </table>
           </div>
         </div>
 

--- a/client/src/app/troncs/depart/departTronc.html
+++ b/client/src/app/troncs/depart/departTronc.html
@@ -59,6 +59,7 @@
                     <th>Tronc             </th>
                     <th>Prénom            </th>
                     <th>Nom               </th>
+                    <th>Point de quête    </th>
                     <th>Départ Théo       </th>
                     <th>TroncQueteur      </th>
                   </tr>
@@ -70,6 +71,7 @@
                     <td style="text-align: center">{{::t.id }}</td>
                     <td>{{::t.first_name  }}</td>
                     <td>{{::t.last_name   }}</td>
+                    <td>{{::t.point_quete_name}}</td>
                     <td>{{::t.depart_theorique | date:'dd/MM/yyyy HH:mm'}}</td>
                     <td style="text-align: center"><a ng-href="/#!/tronc_queteur/edit/{{::t.tronc_queteur_id}}" target='_blank'>{{::t.tronc_queteur_id}}</a></td>
                   </tr>

--- a/client/src/app/troncs/retour/retourTronc.html
+++ b/client/src/app/troncs/retour/retourTronc.html
@@ -120,38 +120,6 @@
                 </div>
               </div>
 
-              <div class="row visible-lg-block" ng-show="!(rt.current.tronc_queteur.id>0)"  ng-cloak>
-                <div class="col-md-8">
-                  <span class="label label-primary">Liste des troncs prêts au retour</span>
-
-                  <table class="table table-hover table-condensed histo">
-                    <thead>
-                    <tr>
-                      <th>Sélect            </th>
-                      <th>id                </th>
-                      <th>Prénom            </th>
-                      <th>Nom               </th>
-                      <th>Point de quête    </th>
-                      <th>Départ            </th>
-                      <th>TroncQueteur      </th>
-                    </tr>
-                    </thead>
-
-                    <tbody>
-                    <tr ng-repeat="t in rt.current.troncsForRetour.rows" ng-class-odd="'oddRows'"  ng-class-even="'evenRows'">
-                      <td><button type="button" ng-model="singleModel" class="btn btn-primary" uib-btn-checkbox ng-click="rt.troncDecodedAndFoundInDB(t)"><span class="glyphicon glyphicon-floppy-disk"  aria-hidden="true"></span></button></td>
-                      <td style="text-align: center">{{::t.id}}</td>
-                      <td>{{::t.first_name  }}</td>
-                      <td>{{::t.last_name   }}</td>
-                      <td>{{::t.point_quete_name}}</td>
-                      <td>{{::t.depart | date:'dd/MM/yyyy HH:mm'}}</td>
-                      <td style="text-align: center"><a ng-href="/#!/tronc_queteur/edit/{{::t.tronc_queteur_id}}" target='_blank'>{{::t.tronc_queteur_id}}</a></td>
-                    </tr>
-                    </tbody>
-                  </table>
-                </div>
-              </div>
-
               <div class="row">
                 <div class="col-md-12">
                   <div class="alert alert-info" role="alert" style="text-align: center;vertical-align: middle;">
@@ -295,6 +263,38 @@
                      rt.current.tronc_queteur.dateDepartIsMissing === true && rt.current.tronc_queteur.depart.getHours() == 0 && rt.current.tronc_queteur.depart.getMinutes() == 0 ||
                      rt.current.tronc_queteur.troncFromPreviousYear ||
                      rt.checkDeltaDepartRetourIsCorrect()==2" />
+            </div>
+          </div>
+
+          <div class="row visible-lg-block" ng-show="!(rt.current.tronc_queteur.id>0)"  ng-cloak>
+            <div class="col-md-12">
+              <span class="label label-primary">Liste des troncs prêts au retour</span>
+
+              <table class="table table-hover table-condensed histo">
+                <thead>
+                <tr>
+                  <th>Sélect            </th>
+                  <th>id                </th>
+                  <th>Prénom            </th>
+                  <th>Nom               </th>
+                  <th>Point de quête    </th>
+                  <th>Départ            </th>
+                  <th>TroncQueteur      </th>
+                </tr>
+                </thead>
+
+                <tbody>
+                <tr ng-repeat="t in rt.current.troncsForRetour.rows" ng-class-odd="'oddRows'"  ng-class-even="'evenRows'">
+                  <td><button type="button" ng-model="singleModel" class="btn btn-primary" uib-btn-checkbox ng-click="rt.troncDecodedAndFoundInDB(t)"><span class="glyphicon glyphicon-floppy-disk"  aria-hidden="true"></span></button></td>
+                  <td style="text-align: center">{{::t.id}}</td>
+                  <td>{{::t.first_name  }}</td>
+                  <td>{{::t.last_name   }}</td>
+                  <td>{{::t.point_quete_name}}</td>
+                  <td>{{::t.depart | date:'dd/MM/yyyy HH:mm'}}</td>
+                  <td style="text-align: center"><a ng-href="/#!/tronc_queteur/edit/{{::t.tronc_queteur_id}}" target='_blank'>{{::t.tronc_queteur_id}}</a></td>
+                </tr>
+                </tbody>
+              </table>
             </div>
           </div>
 

--- a/client/src/app/troncs/retour/retourTronc.html
+++ b/client/src/app/troncs/retour/retourTronc.html
@@ -131,6 +131,7 @@
                       <th>id                </th>
                       <th>Prénom            </th>
                       <th>Nom               </th>
+                      <th>Point de quête    </th>
                       <th>Départ            </th>
                       <th>TroncQueteur      </th>
                     </tr>
@@ -142,6 +143,7 @@
                       <td style="text-align: center">{{::t.id}}</td>
                       <td>{{::t.first_name  }}</td>
                       <td>{{::t.last_name   }}</td>
+                      <td>{{::t.point_quete_name}}</td>
                       <td>{{::t.depart | date:'dd/MM/yyyy HH:mm'}}</td>
                       <td style="text-align: center"><a ng-href="/#!/tronc_queteur/edit/{{::t.tronc_queteur_id}}" target='_blank'>{{::t.tronc_queteur_id}}</a></td>
                     </tr>

--- a/client/src/app/troncs/troncQueteur/troncQueteur.controller.js
+++ b/client/src/app/troncs/troncQueteur/troncQueteur.controller.js
@@ -918,7 +918,25 @@
 
     vm.print=function()
     {
-      window.print();
+      //instrumentation: helps diagnose user reports of "button stays greyed" or
+      //"nothing happens on click". the log line lets us confirm in the browser
+      //console (F12) that the handler is actually invoked and that the current
+      //tronc_queteur is loaded.
+      var tqId = (vm.current && vm.current.tronc_queteur) ? vm.current.tronc_queteur.id : null;
+      $log.debug("[print] click — tronc_queteur.id=" + tqId);
+      try
+      {
+        //after window.print() closes, the button keeps :focus and Bootstrap
+        //btn-info renders it darker, which users perceive as "greyed out".
+        //blur() before the call so the button returns to its default colour.
+        var el = document.getElementById("tronc_queteur_print");
+        if (el) { el.blur(); }
+        window.print();
+      }
+      catch (e)
+      {
+        $log.error("[print] window.print() failed", e);
+      }
     };
 
 

--- a/client/src/app/troncs/troncQueteur/troncQueteur.html
+++ b/client/src/app/troncs/troncQueteur/troncQueteur.html
@@ -395,9 +395,9 @@
         </div>
 
         <div class="row visible-lg-block" ng-show="!(tq.current.tronc_queteur.id>0)"  ng-cloak>
-          <div class="col-md-8 col-md-offset-4">
+          <div class="col-md-12">
 
-            <span class="label label-primary">Liste des troncs prêts au départ</span>
+            <span class="label label-primary">Liste des troncs prêts au comptage</span>
 
             <table class="table table-hover table-condensed histo" ng-cloak>
               <thead>
@@ -406,6 +406,7 @@
                 <th>ID                </th>
                 <th>Prénom            </th>
                 <th>Nom               </th>
+                <th>Point de quête    </th>
                 <th>Départ            </th>
                 <th>Retour            </th>
                 <th>TroncQueteur      </th>
@@ -418,6 +419,7 @@
                 <td>{{::t.id}}</td>
                 <td>{{::t.first_name  }}</td>
                 <td>{{::t.last_name   }}</td>
+                <td>{{::t.point_quete_name}}</td>
                 <td>{{::t.depart | date:'dd/MM/yyyy HH:mm'}}</td>
                 <td>{{::t.retour | date:'dd/MM/yyyy HH:mm'}}</td>
                 <td><a ng-href="/#!/tronc_queteur/edit/{{::t.tronc_queteur_id}}" target='_blank'>{{::t.tronc_queteur_id}}</a></td>
@@ -1312,28 +1314,28 @@
               <tr>
                 <th>Total</th>
                 <td>{{tq.current.coinsMoneyBagDetails.amount| currency : "€" : 2}}</td>
-                <td ng-hide="tq.current.readOnlyView">{{tq.current.coinsMoneyBagDetails.amount +
-                  tq.current.tronc_queteur.euro2   * 2     +
-                  tq.current.tronc_queteur.euro1   * 1     +
-                  tq.current.tronc_queteur.cents50 * 0.5   +
-                  tq.current.tronc_queteur.cents20 * 0.2   +
-                  tq.current.tronc_queteur.cents10 * 0.1   +
-                  tq.current.tronc_queteur.cents5  * 0.05  +
-                  tq.current.tronc_queteur.cents2  * 0.02  +
-                  tq.current.tronc_queteur.cent1   * 0.01  | currency : "€" : 2}}</td>
+                <td ng-hide="tq.current.readOnlyView">{{(tq.current.coinsMoneyBagDetails.amount || 0) +
+                  (tq.current.tronc_queteur.euro2   || 0) * 2     +
+                  (tq.current.tronc_queteur.euro1   || 0) * 1     +
+                  (tq.current.tronc_queteur.cents50 || 0) * 0.5   +
+                  (tq.current.tronc_queteur.cents20 || 0) * 0.2   +
+                  (tq.current.tronc_queteur.cents10 || 0) * 0.1   +
+                  (tq.current.tronc_queteur.cents5  || 0) * 0.05  +
+                  (tq.current.tronc_queteur.cents2  || 0) * 0.02  +
+                  (tq.current.tronc_queteur.cent1   || 0) * 0.01  | currency : "€" : 2}}</td>
               </tr>
               <tr>
                 <th>Poids</th>
                 <td>{{tq.current.coinsMoneyBagDetails.weight | currency : "g" : 2 }}</td>
-                <td ng-hide="tq.current.readOnlyView">{{tq.current.coinsMoneyBagDetails.weight +
-                  tq.current.tronc_queteur.euro2   *  8.5  +
-                  tq.current.tronc_queteur.euro1   *  7.5  +
-                  tq.current.tronc_queteur.cents50 *  7.8  +
-                  tq.current.tronc_queteur.cents20 *  5.74 +
-                  tq.current.tronc_queteur.cents10 *  4.1  +
-                  tq.current.tronc_queteur.cents5  *  3.92 +
-                  tq.current.tronc_queteur.cents2  *  3.06 +
-                  tq.current.tronc_queteur.cent1   *  2.3  | currency : "g" : 2 }}</td>
+                <td ng-hide="tq.current.readOnlyView">{{(tq.current.coinsMoneyBagDetails.weight || 0) +
+                  (tq.current.tronc_queteur.euro2   || 0) *  8.5  +
+                  (tq.current.tronc_queteur.euro1   || 0) *  7.5  +
+                  (tq.current.tronc_queteur.cents50 || 0) *  7.8  +
+                  (tq.current.tronc_queteur.cents20 || 0) *  5.74 +
+                  (tq.current.tronc_queteur.cents10 || 0) *  4.1  +
+                  (tq.current.tronc_queteur.cents5  || 0) *  3.92 +
+                  (tq.current.tronc_queteur.cents2  || 0) *  3.06 +
+                  (tq.current.tronc_queteur.cent1   || 0) *  2.3  | currency : "g" : 2 }}</td>
               </tr>
             </table>
 
@@ -1351,26 +1353,26 @@
               <tr>
                 <th>Total</th>
                 <td>{{tq.current.billsMoneyBagDetails.amount| currency : "€" : 2}}</td>
-                <td ng-hide="tq.current.readOnlyView">{{tq.current.billsMoneyBagDetails.amount +
-                 tq.current.tronc_queteur.euro5   * 5   +
-                 tq.current.tronc_queteur.euro10  * 10  +
-                 tq.current.tronc_queteur.euro20  * 20  +
-                 tq.current.tronc_queteur.euro50  * 50  +
-                 tq.current.tronc_queteur.euro100 * 100 +
-                 tq.current.tronc_queteur.euro200 * 200 +
-                 tq.current.tronc_queteur.euro500 * 500  | currency : "€" : 2}}</td>
+                <td ng-hide="tq.current.readOnlyView">{{(tq.current.billsMoneyBagDetails.amount || 0) +
+                 (tq.current.tronc_queteur.euro5   || 0) * 5   +
+                 (tq.current.tronc_queteur.euro10  || 0) * 10  +
+                 (tq.current.tronc_queteur.euro20  || 0) * 20  +
+                 (tq.current.tronc_queteur.euro50  || 0) * 50  +
+                 (tq.current.tronc_queteur.euro100 || 0) * 100 +
+                 (tq.current.tronc_queteur.euro200 || 0) * 200 +
+                 (tq.current.tronc_queteur.euro500 || 0) * 500  | currency : "€" : 2}}</td>
               </tr>
               <tr>
                 <th>Poids</th>
                 <td>{{tq.current.billsMoneyBagDetails.weight| currency : "g" : 2}}</td>
-                <td ng-hide="tq.current.readOnlyView">{{tq.current.billsMoneyBagDetails.weight +
-                 tq.current.tronc_queteur.euro5   *  1.1 +
-                 tq.current.tronc_queteur.euro10  *  1.1 +
-                 tq.current.tronc_queteur.euro20  *  1   +
-                 tq.current.tronc_queteur.euro50  *  0.9 +
-                 tq.current.tronc_queteur.euro100 *  0.8 +
-                 tq.current.tronc_queteur.euro200 *  0.7 +
-                 tq.current.tronc_queteur.euro500 *  0.6 | currency : "g" : 2}}</td>
+                <td ng-hide="tq.current.readOnlyView">{{(tq.current.billsMoneyBagDetails.weight || 0) +
+                 (tq.current.tronc_queteur.euro5   || 0) *  1.1 +
+                 (tq.current.tronc_queteur.euro10  || 0) *  1.1 +
+                 (tq.current.tronc_queteur.euro20  || 0) *  1   +
+                 (tq.current.tronc_queteur.euro50  || 0) *  0.9 +
+                 (tq.current.tronc_queteur.euro100 || 0) *  0.8 +
+                 (tq.current.tronc_queteur.euro200 || 0) *  0.7 +
+                 (tq.current.tronc_queteur.euro500 || 0) *  0.6 | currency : "g" : 2}}</td>
               </tr>
             </table>
           </div>

--- a/run_local.md
+++ b/run_local.md
@@ -77,8 +77,17 @@ make ps              # services en cours
 ```bash
 make composer cmd="require foo/bar"
 make composer-install                # re-run composer install
+make refresh-di                      # purge cache PHP-DI + autoload optimisé
 make npm cmd="install --save-dev lodash"
 ```
+
+> 💡 `make refresh-di` est à lancer dès que `server/src/dependencies.php`
+> change (signature d'un constructeur de service, factory réécrite, etc.).
+> Le container compilé `/tmp/php-di-compiled/CompiledContainer.php` est
+> persisté dans le volume Docker `php-di-cache` et survit aux
+> `make restart` / `make down` : sans purge explicite, l'ancienne fabrique
+> continue d'injecter les anciens arguments. `run_local.sh` et
+> `GCP/deploy_back.sh` appellent déjà ce script automatiquement.
 
 > ⚠️ **Ne jamais lancer `npm install` / `gulp` directement depuis
 > l'hôte.** Le front tourne sur Node 22 + Gulp 5 + dart-sass dans le

--- a/run_local.sh
+++ b/run_local.sh
@@ -145,6 +145,19 @@ if [[ $SKIP_DEPS -eq 0 ]]; then
 fi
 
 # -----------------------------------------------------------------------------
+# 7a. Refresh PHP-DI compiled container (catches stale wiring on rebuilds)
+# -----------------------------------------------------------------------------
+# The compiled container at /tmp/php-di-compiled/CompiledContainer.php is
+# persisted in the `php-di-cache` Docker volume across container restarts and
+# even `docker compose down`. Any change to dependencies.php (constructor
+# signatures, factory wiring) needs the compiled container to be regenerated,
+# otherwise the stale factory keeps injecting the previous arguments. Re-run
+# every bootstrap to guarantee freshness; the file is regenerated lazily on
+# the first request after deletion.
+say "Refreshing PHP-DI compiled container + optimizing autoload"
+docker compose exec -T -w /app/server php-fpm bash regenerate-php-di-cache.sh
+
+# -----------------------------------------------------------------------------
 # 7bis. Phinx migrations (mirrors GCP/deploy_back.sh pattern)
 # -----------------------------------------------------------------------------
 # ~/.cred/phinx.yml carries root credentials for every env. Copy it onto the

--- a/server/regenerate-php-di-cache.sh
+++ b/server/regenerate-php-di-cache.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
-#https://getcomposer.org/doc/articles/autoloader-optimization.md
-rm -f  /tmp/php-di-compiled/CompiledContainer.php
+# Purge the compiled PHP-DI container and regenerate the optimized Composer
+# autoloader. Intended to be run *inside* the php-fpm container (where the
+# /tmp/php-di-compiled volume lives) — either via `make refresh-di`, by
+# run_local.sh during bootstrap, or by GCP/deploy_back.sh before deploy.
+#
+# https://php-di.org/doc/performances.html
+# https://getcomposer.org/doc/articles/autoloader-optimization.md
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+rm -f /tmp/php-di-compiled/CompiledContainer.php
 composer dump-autoload -o

--- a/server/src/DBService/MoneyBagDBService.php
+++ b/server/src/DBService/MoneyBagDBService.php
@@ -35,12 +35,14 @@ SELECT DISTINCT t.money_bag_id FROM
   WHERE  tq.$column   like :query
   AND YEAR(tq.depart) =    YEAR(NOW())
   AND tq.ul_id        =    :ul_id
+  AND tq.deleted      =    0
   UNION
   SELECT DISTINCT(nd.$column) as money_bag_id
   FROM   named_donation nd
   WHERE  nd.$column          like :query
   AND YEAR(nd.donation_date) =    YEAR(NOW())
   AND nd.ul_id               =    :ul_id
+  AND nd.deleted             =    0
 ) as t
 ORDER BY t.money_bag_id DESC
 ";

--- a/server/src/DBService/MoneyBagDBService.php
+++ b/server/src/DBService/MoneyBagDBService.php
@@ -73,7 +73,7 @@ ORDER BY t.money_bag_id DESC
 
 
     $sql = "
-SELECT coins_money_bag_id,
+SELECT MIN(coins_money_bag_id) as coins_money_bag_id,
     COALESCE(SUM(
         euro2   * 2     +
         euro1   * 1     +
@@ -166,7 +166,7 @@ nd.cent1
     ];
 
     $sql = "
-SELECT bills_money_bag_id,
+SELECT MIN(bills_money_bag_id) as bills_money_bag_id,
        COALESCE(SUM(
         euro5    *5   +
         euro10   *10  +

--- a/server/src/DBService/MoneyBagDBService.php
+++ b/server/src/DBService/MoneyBagDBService.php
@@ -72,7 +72,7 @@ ORDER BY t.money_bag_id DESC
 
     $sql = "
 SELECT coins_money_bag_id,
-    SUM(
+    COALESCE(SUM(
         euro2   * 2     +
         euro1   * 1     +
         cents50 * 0.5   +
@@ -81,7 +81,7 @@ SELECT coins_money_bag_id,
         cents5  * 0.05  +
         cents2  * 0.02  +
         cent1   * 0.01
-    ) as amount,
+    ), 0) as amount,
 SUM(euro2    *2   ) as  total_euro2  ,
 SUM(euro1    *1   ) as  total_euro1  ,
 SUM(cents50  *0.5 ) as  total_cents50,
@@ -98,7 +98,7 @@ SUM(cents10) as  count_cents10       ,
 SUM(cents5 ) as  count_cents5        ,
 SUM(cents2 ) as  count_cents2        ,
 SUM(cent1  ) as  count_cent1         ,
-    SUM(
+    COALESCE(SUM(
      euro2    * 8.5  +
      euro1    * 7.5  +
      cents50  * 7.8  +
@@ -107,7 +107,7 @@ SUM(cent1  ) as  count_cent1         ,
      cents5   * 3.92 +
      cents2   * 3.06 +
      cent1    * 2.3
-    ) as weight
+    ), 0) as weight
 from (
 select
 tq.coins_money_bag_id,
@@ -165,7 +165,7 @@ nd.cent1
 
     $sql = "
 SELECT bills_money_bag_id,
-       SUM(
+       COALESCE(SUM(
         euro5    *5   +
         euro10   *10  +
         euro20   *20  +
@@ -173,7 +173,7 @@ SELECT bills_money_bag_id,
         euro100  *100 +
         euro200  *200 +
         euro500  *500
-    ) as amount,
+    ), 0) as amount,
 SUM(euro5    *5   ) as  total_euro5  ,
 SUM(euro10   *10  ) as  total_euro10 ,
 SUM(euro20   *20  ) as  total_euro20 ,
@@ -190,7 +190,7 @@ SUM(euro100) as  count_euro100       ,
 SUM(euro200) as  count_euro200       ,
 SUM(euro500) as  count_euro500       ,
 
-    SUM(
+    COALESCE(SUM(
      euro500  * 1.1  +
      euro200  * 1.1  +
      euro100  * 1    +
@@ -198,7 +198,7 @@ SUM(euro500) as  count_euro500       ,
      euro20   * 0.8  +
      euro10   * 0.7  +
      euro5    * 0.6
-    ) as weight
+    ), 0) as weight
 from (
 select
 tq.bills_money_bag_id,

--- a/server/src/DBService/TroncDBService.php
+++ b/server/src/DBService/TroncDBService.php
@@ -330,9 +330,11 @@ ORDER BY tq.`depart` DESC, tq.`id` desc
     $parameters = ["ul_id"  => $ulId];
     $sql = "
 SELECT t.`id`, tq.`id` as `tronc_queteur_id`, q.`first_name`, q.`last_name`, tq.`depart`, tq.`retour`,
-       t.`ul_id`, t.`created`, t.`enabled`, t.`notes`, t.`type`
-FROM   tronc         as t, 
-       tronc_queteur as tq, 
+       t.`ul_id`, t.`created`, t.`enabled`, t.`notes`, t.`type`,
+       pq.`name` as `point_quete_name`
+FROM   tronc         as t,
+       tronc_queteur as tq
+       LEFT JOIN point_quete as pq ON tq.`point_quete_id` = pq.`id`,
        queteur       as q
 where tq.`tronc_id`   = t.`id`
 AND   tq.`queteur_id` = q.`id`
@@ -341,7 +343,7 @@ AND   tq.`deleted`    = false
 AND   YEAR(tq.`depart_theorique`) = YEAR(CURRENT_DATE())
 AND   tq.`depart`     is not null
 AND   tq.`retour`     is not null
-AND   tq.`comptage`   is null  
+AND   tq.`comptage`   is null
 AND   t.`ul_id`       = :ul_id
 ORDER BY tq.`retour` DESC, tq.`id` desc
 ";

--- a/server/src/DBService/TroncDBService.php
+++ b/server/src/DBService/TroncDBService.php
@@ -249,9 +249,11 @@ WHERE  `ul_id`           = :ul_id
     $parameters = ["ul_id"  => $ulId];
     $sql = "
 SELECT t.`id`, tq.`id` as `tronc_queteur_id`, q.`first_name`, q.`last_name`, tq.`depart_theorique`,
-       t.`ul_id`, t.`created`, t.`enabled`, t.`notes`, t.`type`
-FROM   tronc         as t, 
-       tronc_queteur as tq, 
+       t.`ul_id`, t.`created`, t.`enabled`, t.`notes`, t.`type`,
+       pq.`name` as `point_quete_name`
+FROM   tronc         as t,
+       tronc_queteur as tq
+       LEFT JOIN point_quete as pq ON tq.`point_quete_id` = pq.`id`,
        queteur       as q
 where tq.`tronc_id`   = t.`id`
 AND   tq.`queteur_id` = q.`id`
@@ -287,9 +289,11 @@ ORDER BY tq.`depart_theorique` DESC, tq.`id` desc
     $parameters = ["ul_id"  => $ulId];
     $sql = "
 SELECT t.`id`, tq.`id` as `tronc_queteur_id`, q.`first_name`, q.`last_name`, tq.`depart`,
-       t.`ul_id`, t.`created`, t.`enabled`, t.`notes`, t.`type`
-FROM   tronc         as t, 
-       tronc_queteur as tq, 
+       t.`ul_id`, t.`created`, t.`enabled`, t.`notes`, t.`type`,
+       pq.`name` as `point_quete_name`
+FROM   tronc         as t,
+       tronc_queteur as tq
+       LEFT JOIN point_quete as pq ON tq.`point_quete_id` = pq.`id`,
        queteur       as q
 where tq.`tronc_id`   = t.`id`
 AND   tq.`queteur_id` = q.`id`

--- a/server/src/Entity/TroncEntity.php
+++ b/server/src/Entity/TroncEntity.php
@@ -94,6 +94,13 @@ class TroncEntity extends Entity
    */
   public ?Carbon $retour ;
 
+  /**
+   * GetTroncForDepart, GetTroncForRetour where we list troncs with their assigned point de quête
+   * @OA\Property()
+   * @var ?string $point_quete_name Name of the associated point de quête
+   */
+  public ?string $point_quete_name;
+
 
 
   protected array $_fieldList = ['id','ul_id','created','enabled','notes','nombreTronc'];
@@ -121,6 +128,7 @@ class TroncEntity extends Entity
     $this->getDate   ('depart_theorique'  , $data);
     $this->getDate   ('depart'            , $data);
     $this->getDate   ('retour'            , $data);
+    $this->getString ('point_quete_name'  , $data, 100);
 
 
     }


### PR DESCRIPTION
## Résumé

Ajoute la colonne **Point de quête** (PQ) aux listes Départ, Retour et Comptage, et corrige une série de bugs découverts en route sur le détail des sacs de banque (Comptage), ainsi qu'un cache PHP-DI obsolète qui faisait sauter les routes après ajout de service.

9 commits, 12 fichiers, +194 / −120.

## Commits

| # | SHA | Type | Sujet |
|---|---|---|---|
| 1 | `de482f6` | feat | Add point de quête column to depart and retour lists |
| 2 | `b44f7c6` | fix | Coalesce `SUM(amount/weight)` to 0 in MoneyBag details |
| 3 | `fadb060` | fix | Guard NaN propagation in 'Après ce tronc' arithmetic |
| 4 | `9058536` | fix | Exclude deleted rows from money bag id autocomplete |
| 5 | `8f5a48f` | fix | Wrap `*_money_bag_id` in `MIN()` (ONLY_FULL_GROUP_BY) |
| 6 | `db324c3` | chore | Automate PHP-DI compiled container purge (local + GCP) |
| 7 | `4abd2be` | feat | Join `point_quete` to feed PQ column on comptage list |
| 8 | `549134b` | ui | Move depart/retour ready-troncs lists out of the form column |
| 9 | `a7cc912` | chore | Instrument print handler to diagnose user reports |

## Détail par thème

### Colonne Point de quête
- Backend : `TroncDBService::getTroncsForComptage` joint `point_quete` et expose le libellé ; `TroncEntity` ajoute le champ.
- Frontend : la colonne PQ apparaît dans les tables Départ, Retour, Comptage.
- Layout : les tables "Liste des troncs prêts" sont remontées hors du `col-md-8` parent pour profiter d'un `col-md-12` pleine page (la 7e colonne ne tient pas en 66 %).

### Détail sac de banque (Comptage)
- `SUM(amount)` / `SUM(weight)` peuvent renvoyer NULL pour un sac vide → coalesce à 0.
- Sécurise côté JS le calcul "Après ce tronc" contre la propagation de NaN.
- Exclut les `deleted=1` de l'autocomplete des Money Bag ID.
- Wrap des `*_money_bag_id` dans `MIN()` pour satisfaire `ONLY_FULL_GROUP_BY` (MySQL 8 strict mode).

### Outillage PHP-DI
- Le container compilé devenait obsolète après ajout d'un service → routes en 500.
- `regenerate-php-di-cache.sh` est désormais appelé automatiquement par `run_local.sh` (après `composer install`) et par `GCP/deploy_back.sh` (avant `phinx migrate`).
- Cible `make refresh-di` pour purger manuellement.
- Doc dans `run_local.md`.

### Diagnostic bouton Imprimer
- Reports utilisateurs intermittents ("bouton grisé" / "rien ne se passe").
- `vm.print()` ajoute un `$log.debug` + `blur()` (élimine le faux-positif `:focus` Bootstrap) + `try/catch` autour de `window.print()`.
- Aucun changement de comportement happy path.

## Tests

- Aucune spec touchée. `troncQueteur.controller.js` n'a pas de spec dédiée. Les tests existants (frontend Karma + backend PHPUnit) ne sont pas impactés par ce périmètre.
- Vérification manuelle locale OK :
  - Comptage : colonne PQ visible, sélection PQ filtre la liste, détail sac correct (Actuel / Après).
  - Départ / Retour : colonne PQ visible, tables sur toute la largeur en ≥ lg.
  - Sauvegarde Comptage OK (plus de SQL ONLY_FULL_GROUP_BY).

## Notes de déploiement

- **GCP** : le script `deploy_back.sh` purge maintenant le container PHP-DI compilé automatiquement avant `phinx migrate`. Aucune action manuelle requise.
- **Local** : `./run_local.sh` purge le container après `composer install`. `make refresh-di` disponible si besoin ponctuel.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author