### PR TITLE
fix: mailing reliability + admin POST bypass + i18n cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,12 @@ HOST_PORT_FRONT=3000     # gulp serve browser-sync    -> http://localhost:3000
 HOST_PORT_FRONT_UI=3001  # gulp serve BS control UI
 
 # ---- PHP runtime ----
-PHP_DISPLAY_ERRORS=On
+# Keep Off: this is a JSON API. Any PHP warning/notice/deprecation rendered as
+# HTML inline in the response body corrupts JSON output (e.g. the SendGrid lib
+# emits a `Deprecated: curl_close()` on PHP 8.5 that breaks /rest/*/mailing).
+# PHP errors stay visible via `docker compose logs php-fpm` (stderr) and via
+# the Slim logger (server/logs/local-logs.log).
+PHP_DISPLAY_ERRORS=Off
 XDEBUG_MODE=debug            # set to `off` to disable step-debugging
 
 # ---- Database ----

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DC       := docker compose
 PHP_EXEC := $(DC) exec -T php-fpm
 NODE_EXEC:= $(DC) exec -T node-client
 
-.PHONY: help init up down restart build rebuild logs ps \
+.PHONY: help init up down restart build rebuild logs logs-php logs-php-errors ps \
         composer-install composer-update composer npm \
         phinx-migrate phinx-rollback phinx \
         gulp-serve gulp-build \
@@ -43,6 +43,12 @@ rebuild: ## Rebuild images from scratch (no cache)
 
 logs: ## Tail logs from all services (Ctrl-C to quit)
 	$(DC) logs -f --tail=100
+
+logs-php: ## Tail PHP-FPM logs (warnings/notices/deprecations are sent here, Ctrl-C to quit)
+	$(DC) logs -f --tail=200 php-fpm
+
+logs-php-errors: ## Show recent PHP errors/warnings/deprecations from the last 30 minutes
+	@$(DC) logs --since=30m php-fpm 2>&1 | grep -iE 'deprecated|warning|notice|fatal|parse error|uncaught' || echo "  (no PHP errors in the last 30 minutes)"
 
 ps: ## List running services
 	$(DC) ps

--- a/client/src/app/admin/Settings/settings.html
+++ b/client/src/app/admin/Settings/settings.html
@@ -166,7 +166,7 @@
                   <div class="row">
                     <div class="col-md-6">
                       <div class="form-group" ng-class="{'has-error':ulSettingsForm.admin_man.$invalid}">
-                        <label for="admin_manRadio1" class="control-label">Sexe</label>  <br/>
+                        <label for="admin_manRadio1" class="control-label">Genre</label>  <br/>
                         <label class="radio-inline">
                           <input type="radio" name="admin_man" id="admin_manRadio1" ng-model="s.settings.admin_man" ng-value="true" required ng-disabled="s.refreshInProgressSettings"> Homme
                         </label>
@@ -266,7 +266,7 @@
                   <div class="row">
                     <div class="col-md-6">
                       <div class="form-group" ng-class="{'has-error':ulSettingsForm.tresorier_man.$invalid}">
-                        <label for="tresorier_manRadio1" class="control-label">Sexe</label>  <br/>
+                        <label for="tresorier_manRadio1" class="control-label">Genre</label>  <br/>
                         <label class="radio-inline">
                           <input type="radio" name="tresorier_man" id="tresorier_manRadio1" ng-model="s.settings.tresorier_man" ng-value="true" required ng-disabled="s.refreshInProgressSettings"> Homme
                         </label>
@@ -369,7 +369,7 @@
                   <div class="row">
                     <div class="col-md-6">
                       <div class="form-group" ng-class="{'has-error':ulSettingsForm.president_man.$invalid}">
-                        <label for="president_manRadio1" class="control-label">Sexe</label>  <br/>
+                        <label for="president_manRadio1" class="control-label">Genre</label>  <br/>
                         <label class="radio-inline">
                           <input type="radio" name="president_man" id="president_manRadio1" ng-model="s.settings.president_man" ng-value="true" required ng-disabled="s.refreshInProgressSettings"> Homme
                         </label>

--- a/client/src/app/admin/ULRegistration/ULRegistrationValidation/ulRegistrationValidation.html
+++ b/client/src/app/admin/ULRegistration/ULRegistrationValidation/ulRegistrationValidation.html
@@ -98,7 +98,7 @@
                   <div class="row">
                     <div class="col-md-6">
                       <div class="form-group" ng-class="{'has-error':ulSettingsForm.admin_man.$invalid}">
-                        <label for="admin_manRadio1" class="control-label">Sexe</label>  <br/>
+                        <label for="admin_manRadio1" class="control-label">Genre</label>  <br/>
                         <label class="radio-inline">
                           <input type="radio" name="admin_man" id="admin_manRadio1" ng-model="urv.settings.admin_man" ng-value="true" required> Homme
                         </label>
@@ -190,7 +190,7 @@
                   <div class="row">
                     <div class="col-md-6">
                       <div class="form-group" ng-class="{'has-error':ulSettingsForm.tresorier_man.$invalid}">
-                        <label for="tresorier_manRadio1" class="control-label">Sexe</label>  <br/>
+                        <label for="tresorier_manRadio1" class="control-label">Genre</label>  <br/>
                         <label class="radio-inline">
                           <input type="radio" name="tresorier_man" id="tresorier_manRadio1" ng-model="urv.settings.tresorier_man" ng-value="true" required> Homme
                         </label>
@@ -284,7 +284,7 @@
                   <div class="row">
                     <div class="col-md-6">
                       <div class="form-group" ng-class="{'has-error':ulSettingsForm.president_man.$invalid}">
-                        <label for="president_manRadio1" class="control-label">Sexe</label>  <br/>
+                        <label for="president_manRadio1" class="control-label">Genre</label>  <br/>
                         <label class="radio-inline">
                           <input type="radio" name="president_man" id="president_manRadio1" ng-model="urv.settings.president_man" ng-value="true" required> Homme
                         </label>

--- a/client/src/app/admin/ULRegistration/listULRegistration/listULRegistration.html
+++ b/client/src/app/admin/ULRegistration/listULRegistration/listULRegistration.html
@@ -52,7 +52,7 @@
           <th>UL ID             </th>
           <th>Nom               </th>
           <th>Ville             </th>
-          <th>Admin sexe        </th>
+          <th>Admin genre       </th>
           <th>Admin prénom      </th>
           <th>Admin nom         </th>
           <th>Admin email       </th>

--- a/client/src/app/admin/exportData/exportData.controller.js
+++ b/client/src/app/admin/exportData/exportData.controller.js
@@ -51,7 +51,9 @@
       vm.status   = null;
       //vm.password = Math.random().toString(36).slice(2) + Math.random().toString(36).slice(2);
       vm.exportInProgress = true;
-      ExportDataResource.save().$promise.then(vm.exportDataSuccess, vm.exportDataError);
+      // Send a non-empty body to bypass the anti-scan fail-fast filter in
+      // server/public/rest/index.php which rejects POST/PUT with Content-Length: 0
+      ExportDataResource.save({}, {export: true}).$promise.then(vm.exportDataSuccess, vm.exportDataError);
     };
 
   }

--- a/client/src/app/admin/mailing/launch.html
+++ b/client/src/app/admin/mailing/launch.html
@@ -154,7 +154,7 @@
       <th>prénom </th>
       <th>nom    </th>
       <th>secteur</th>
-      <th>Sexe </th>
+      <th>Genre </th>
       <th>token  </th>
       <th>statut </th>
     </tr>

--- a/client/src/app/admin/mailing/launchMailing.controller.js
+++ b/client/src/app/admin/mailing/launchMailing.controller.js
@@ -99,7 +99,9 @@
     vm.send = function()
     {
       vm.running = true;
-      MailingResource.save(vm.handleMailingSending, vm.handleMailingSendingError);
+      // Non-empty body required to bypass the anti-scan fail-fast filter in
+      // server/public/rest/index.php (rejects POST/PUT with Content-Length: 0)
+      MailingResource.save({}, {sendBatch: true}, vm.handleMailingSending, vm.handleMailingSendingError);
     };
 
 

--- a/client/src/app/main/main.html
+++ b/client/src/app/main/main.html
@@ -203,7 +203,7 @@
                     <li>Le bénévole scan le QR Code sur son mobile ou clique sur le lien</li>
                     <li>Il arrive alors sur le site de RedQuest</li>
                     <li>Il se connect soit avec Gmail, soit Facebook, ou il se créer un compte en spécifiant un email et un mot de passe</li>
-                    <li>Il accède ensuite a un formulaire, lui demandant les informations suivante : nom, prénom, sexe, date de naissance, email, mobile, secteur</li>
+                    <li>Il accède ensuite a un formulaire, lui demandant les informations suivante : nom, prénom, genre, date de naissance, email, mobile, secteur</li>
                     <li>Il valide l'inscription</li>
                     <li>L'administrateur voit alors l'inscription arriver dans le menu de RedCrossQuest: le compteur a droite du menu 'Quêteur' est incrémenté </li>
                     <li>Vous cliquez sur le compteur et accéder à la liste des inscriptions a valider</li>

--- a/client/src/app/queteurs/edit/editQueteur.html
+++ b/client/src/app/queteurs/edit/editQueteur.html
@@ -200,7 +200,7 @@
       <div class="row">
         <div class="col-md-4 col-md-offset-2">
           <div class="form-group" ng-class="{'has-error':queteurForm.man.$invalid}">
-            <label for="manRadio1" class="control-label">Sexe</label>  <br/>
+            <label for="manRadio1" class="control-label">Genre</label>  <br/>
             <label class="radio-inline">
               <input type="radio" name="man" id="manRadio1" ng-model="queteur.current.man" ng-value="true" required> Homme
             </label>

--- a/client/src/app/queteurs/edit/queteurEdit.controller.js
+++ b/client/src/app/queteurs/edit/queteurEdit.controller.js
@@ -540,7 +540,9 @@
     vm.doExportQueteurData=function()
     {
       vm.current.doExportQueteurDataButtonDisabled=true;
-      QueteurResource.exportData({"id":vm.current.id}).$promise.then(function(result){
+      // Explicit non-empty body to bypass the anti-scan fail-fast filter in
+      // server/public/rest/index.php (rejects POST/PUT with Content-Length: 0)
+      QueteurResource.exportData({"id":vm.current.id}, {export: true}).$promise.then(function(result){
         vm.current.exportDataResult = result;
         vm.current.doExportQueteurDataButtonDisabled=false;
       }, vm.errorWhileSavingFunction);

--- a/client/src/app/ulRegistration/register/register.html
+++ b/client/src/app/ulRegistration/register/register.html
@@ -75,7 +75,7 @@
                   <div class="row">
                     <div class="col-md-6">
                       <div class="form-group" ng-class="{'has-error':registerForm.admin_man.$invalid}">
-                        <label for="admin_manRadio1" class="control-label">Sexe</label>  <br/>
+                        <label for="admin_manRadio1" class="control-label">Genre</label>  <br/>
                         <label class="radio-inline">
                           <input type="radio" name="admin_man" id="admin_manRadio1" ng-model="ulr.settings.admin_man" ng-value="true" required> Homme
                         </label>
@@ -177,7 +177,7 @@
                   <div class="row">
                     <div class="col-md-6">
                       <div class="form-group" ng-class="{'has-error':registerForm.tresorier_man.$invalid}">
-                        <label for="tresorier_manRadio1" class="control-label">Sexe</label>  <br/>
+                        <label for="tresorier_manRadio1" class="control-label">Genre</label>  <br/>
                         <label class="radio-inline">
                           <input type="radio" name="tresorier_man" id="tresorier_manRadio1" ng-model="ulr.settings.tresorier_man" ng-value="true" required> Homme
                         </label>
@@ -280,7 +280,7 @@
                   <div class="row">
                     <div class="col-md-6">
                       <div class="form-group" ng-class="{'has-error':registerForm.president_man.$invalid}">
-                        <label for="president_manRadio1" class="control-label">Sexe</label>  <br/>
+                        <label for="president_manRadio1" class="control-label">Genre</label>  <br/>
                         <label class="radio-inline">
                           <input type="radio" name="president_man" id="president_manRadio1" ng-model="ulr.settings.president_man" ng-value="true" required> Homme
                         </label>

--- a/server/src/BusinessService/EmailBusinessService.php
+++ b/server/src/BusinessService/EmailBusinessService.php
@@ -661,7 +661,7 @@ La date d'anonymisation est le ".$anonymiseDateString." et ce token sont conserv
 
     $deploymentType = $this->appSettings['deploymentType'];
     $graphSubdomain = $deploymentType === 'D' ? 'dev.' : ($deploymentType === 'T' ? 'test.' : '');
-    $url = "https://".$graphSubdomain."graph.redcrossquest.com/?i=".$mailingInfoEntity->spotfire_access_token."&g=".$this->appSettings['queteurDashboard'];
+    $url = "https://".$graphSubdomain."graph.redcrossquest.com/merci?uuid=".$mailingInfoEntity->spotfire_access_token;
 
     try
     {

--- a/server/src/BusinessService/EmailBusinessService.php
+++ b/server/src/BusinessService/EmailBusinessService.php
@@ -694,13 +694,39 @@ Pour cela, il suffit de cliquer sur l'image ci-dessous :<br/>
         null, null, $uniteLocaleEntity->email);
 
 
-      $mailingInfoEntity->status = $statusCode;
+      $mailingInfoEntity->status = (string) $statusCode;
       $this->mailingDBService->insertQueteurMailingStatus($mailingInfoEntity->id, $mailingInfoEntity->status);
     }
     catch(Exception $e)
     {
-      $mailingInfoEntity->status = substr($e->getMessage()."", 0,200);
-      $this->mailingDBService->insertQueteurMailingStatus($mailingInfoEntity->id, $mailingInfoEntity->status);
+      // status_code column is VARCHAR(40), truncate to 40 chars
+      $mailingInfoEntity->status = substr($e->getMessage()."", 0, 40);
+      $this->logger->error("sendThanksEmail failed - storing error as status",
+        [
+          'queteur_id' => $mailingInfoEntity->id,
+          'first_name' => $mailingInfoEntity->first_name,
+          'last_name'  => $mailingInfoEntity->last_name,
+          'email'      => $mailingInfoEntity->email,
+          'truncated_status' => $mailingInfoEntity->status,
+          Logger::$EXCEPTION => $e,
+        ]);
+      try
+      {
+        $this->mailingDBService->insertQueteurMailingStatus($mailingInfoEntity->id, $mailingInfoEntity->status);
+      }
+      catch(Exception $insertException)
+      {
+        // typically: duplicate entry on idx_queteur_year (queteur already mailed
+        // this year). Swallow to keep the batch alive — the original error is
+        // already logged above, and the duplicate is logged inside DBService.
+        $this->logger->warning("sendThanksEmail: could not persist error status (likely duplicate, ignoring)",
+          [
+            'queteur_id' => $mailingInfoEntity->id,
+            'first_name' => $mailingInfoEntity->first_name,
+            'last_name'  => $mailingInfoEntity->last_name,
+            Logger::$EXCEPTION => $insertException,
+          ]);
+      }
 
       //Do not rethrow, continue
     }

--- a/server/src/Entity/MailingInfoEntity.php
+++ b/server/src/Entity/MailingInfoEntity.php
@@ -24,7 +24,10 @@ class MailingInfoEntity extends Entity
 
   // not retrieved from DB
 
-  public ?int $status                      ;
+  // SendGrid HTTP status code (e.g. "202") on success, or the truncated
+  // exception message on failure. The DB column status_code is VARCHAR(40),
+  // hence the string type here.
+  public ?string $status                   ;
 
   protected array $_fieldList = ['id', 'email', 'first_name', 'last_name', 'secteur', 'man', 'spotfire_access_token', 'status'];
 

--- a/server/src/Service/MailService.php
+++ b/server/src/Service/MailService.php
@@ -118,7 +118,15 @@ class MailService
         }
       }
 
-      $email->addContent("text/html", ($deployment!=''?$deployment.'<br/>':'').$content);
+      // Convert every non-ASCII character of the HTML body to a numeric HTML
+      // entity (`é` -> `&#233;`). The resulting payload is 7-bit ASCII, so it
+      // survives intermediate mail relays that mangle 8-bit UTF-8 bytes (seen
+      // on some Croix-Rouge MTAs where accents arrive as U+FFFD). The HTML
+      // renderer of the recipient mail client decodes the entities back to
+      // the original characters at display time.
+      $htmlBody = ($deployment!=''?$deployment.'<br/>':'').$content;
+      $htmlBody = mb_encode_numericentity($htmlBody, [0x80, 0x10FFFF, 0, 0x10FFFF], 'UTF-8');
+      $email->addContent("text/html", $htmlBody);
 
       if($fileName != null)
       {
@@ -132,7 +140,15 @@ class MailService
       // Prevent In-Reply-To / References headers that cause threading
       // SendGrid does not add them unless set explicitly, so nothing to remove
 
-
+      // Disable SendGrid click & open tracking. The branded link
+      // url8294.redcrossquest.com is served over plain HTTP (enabling HTTPS
+      // would require fronting it with a CDN + custom SSL certificate + a
+      // SendGrid Support ticket - see docs.sendgrid.com/ui/analytics-and-reporting/click-tracking-ssl).
+      // We track link engagement directly in RCQ (Spotfire uuid in the URL),
+      // so SendGrid tracking adds no value and only degrades the user
+      // experience with an HTTP warning on click.
+      $email->setClickTracking(false, false);
+      $email->setOpenTracking(false);
 
       $response = (new SendGrid($this->sendgridAPIKey))->send($email);
 


### PR DESCRIPTION
Bundles several production-tested fixes (deployed in dev / test / prod before merge).

---

## 1. Client — non-empty body on export/mailing POSTs (`0a5a86a`)

Three admin actions were silently failing with **HTTP 400** because their POST requests had `Content-Length: 0`, which is rejected by the fail-fast anti-scan filter in `server/public/rest/index.php` (rule #3) **before Slim boots** (nothing in `local-logs.log`).

| Call site | Issue |
|---|---|
| `ExportDataResource.save()` (UL data export) | 0 arg → empty body → 400 |
| `MailingResource.save(success, error)` (mailing batch send) | 2 functions interpreted as `(success, error)` by AngularJS `$resource` → empty body → 400 |
| `QueteurResource.exportData({id})` (per-queteur export) | Worked by accident; made explicit for robustness |

Fix: pass an explicit non-empty body using the `(params, postData, success, error)` signature of AngularJS `$resource`. Auth context comes from the JWT — backend ignores the body content.

---

## 2. Server — thanks-email URL points to new graph platform (`c626d33`)

| | Before | After |
|---|---|---|
| Path | `/` | `/merci` |
| UUID param | `i=<UUID>` | `uuid=<UUID>` |
| Dashboard selector | `&g=Merci` | (dropped) |

Final URLs: `https://[dev.|test.]graph.redcrossquest.com/merci?uuid={UUID}`.

---

## 3. i18n — "Sexe" → "Genre" in user-facing labels (`4e4d2cf`)

Pure UI string rename across 7 templates: queteur edit, UL registration form + admin validation, settings, mailing batch preview, main page tutorial, listULRegistration. DB column `man` and controllers untouched.

---

## 4. `PHP_DISPLAY_ERRORS=Off` (`eda03e3`)

The API returns JSON. Any PHP warning/notice/deprecation rendered as HTML inline corrupts the response body. Seen in prod: SendGrid lib emits `Deprecated: curl_close()` on PHP 8.5 which broke `/rest/*/mailing` responses. Errors stay visible via `docker compose logs php-fpm` and Slim's `local-logs.log`.

---

## 5. Makefile — `logs-php` / `logs-php-errors` (`4ed9852`)

- `make logs-php`         tail PHP-FPM logs.
- `make logs-php-errors`  grep PHP errors in the last 30 min.

---

## 6. Mailing — 40-char truncation + duplicate-row on thanks-email errors (`8a25724`)

Two production issues in `EmailBusinessService::sendThanksEmail` error path:

1. **VARCHAR(40) overflow** — `mailing_info.status_code` is `VARCHAR(40)` but the catch block stored 200 chars → `Data too long` SQL error masked the original failure.
2. **Duplicate-row crash** — retrying a queteur already mailed this year collided with `idx_queteur_year` → second exception aborted the whole batch.

Fix: truncate error status to 40 chars; nested try/catch swallows the duplicate; original SendGrid/SMTP error logged with full queteur context **before** the fallback INSERT. Also tightens `MailingInfoEntity::$status` from `?int` to `?string` to match column type.

---

## 7. Mail — HTML numeric entities + disable SendGrid tracking (`f57ecea`)

**Non-ASCII → numeric entities**: some intermediate Croix-Rouge MTAs mangled UTF-8 bytes, recipients saw `U+FFFD` replacement chars instead of accents. `mb_encode_numericentity` turns every char above U+007F into `&#NNN;` → pure 7-bit ASCII payload that survives any 7-bit transport.

**Disable SendGrid click & open tracking**: the branded link `url8294.redcrossquest.com` is plain HTTP; mail clients flag the click as insecure. Enabling HTTPS requires CDN+SSL+a SendGrid ticket. We already track engagement via the Spotfire `uuid` in the URL — SendGrid tracking adds no value.

---

## Verification (deployed dev / test / prod)

- UL export → 200 + email received
- Per-queteur export → 200 + email received
- Mailing batch send → polls + sends, no SQL truncation crash on errors, duplicates skipped
- Thanks-email link → `https://[…].graph.redcrossquest.com/merci?uuid=…` opens the dashboard
- Accented chars (`é`, `è`, `à`, `ç`) render correctly in received mails (no `�`)
- SendGrid links no longer go through `url8294.redcrossquest.com`
